### PR TITLE
Fix Integration Test Script Syntax Error (Issue #56)

### DIFF
--- a/test_integration/system_diff_validation.sh
+++ b/test_integration/system_diff_validation.sh
@@ -150,8 +150,9 @@ create_mock_coverage_json() {
         local line_count
         line_count=$(wc -l < "$source_file" || echo "10")
         
-        json_content="${json_content}"'{"filename": "'$(basename "$source_file")'",'
-        json_content="${json_content}"'"lines": ['
+        filename=$(basename "$source_file")
+        json_content="${json_content}{\"filename\": \"${filename}\","
+        json_content="${json_content}\"lines\": ["
         
         # Create mock line coverage (some covered, some not)
         for ((i=1; i<=line_count && i<=10; i++)); do
@@ -159,10 +160,10 @@ create_mock_coverage_json() {
                 json_content="${json_content},"
             fi
             local hits=$((RANDOM % 10))
-            json_content="${json_content}"'{"line_number": '"$i"', "execution_count": '"$hits"', "is_executable": true}'
+            json_content="${json_content}"'{"line_number": '"${i}"', "execution_count": '"${hits}"', "is_executable": true}'
         done
         
-        json_content="${json_content}"]}"
+        json_content="${json_content}]}"
     done
     
     json_content="${json_content}]}"


### PR DESCRIPTION
## Summary
Fixed critical shell script syntax error in `test_integration/system_diff_validation.sh` that was preventing automated testing infrastructure from running.

**Error Fixed:** `unexpected EOF while looking for matching quote` on line 421

## Root Cause
Complex quoting patterns in JSON string construction were causing shell parser failures:
- Mixed single/double quotes with command substitution
- Nested quote escaping in JSON property construction
- Incorrect bracket/brace combination syntax
- Unmatched quotes extending to end of file

## Solution
**Systematic Quote Fixing:**
1. **Separated command substitution**: `filename=$(basename "$source_file")` on separate line
2. **Simplified JSON construction**: Used consistent double-quote escaping  
3. **Fixed bracket syntax**: Corrected `"]}"` to `]}"` for proper JSON object closure
4. **Maintained functionality**: All test logic preserved while fixing syntax

## Technical Changes
```bash
# Before (problematic):
json_content="${json_content}"'{"filename": "'$(basename "$source_file")'",'
json_content="${json_content}"'"lines": ['
json_content="${json_content}"'{"line_number": '"$i"', "execution_count": '"$hits"', "is_executable": true}'
json_content="${json_content}"]}"

# After (fixed):
filename=$(basename "$source_file")
json_content="${json_content}{\"filename\": \"${filename}\","
json_content="${json_content}\"lines\": ["
json_content="${json_content}"'{"line_number": '"${i}"', "execution_count": '"${hits}"', "is_executable": true}'
json_content="${json_content}]}"
```

## Validation
- ✅ `bash -n` syntax check passes  
- ✅ Integration test script executes without errors
- ✅ All existing test functionality preserved
- ✅ No breaking changes to test logic
- ✅ System diff validation can now run in CI/CD

## Impact
- **Fixed**: Automated testing infrastructure can validate diff functionality
- **Enabled**: Integration test suite has 100% syntax compliance  
- **Ready**: System-level validation of pycobertura compatibility

Resolves #56

🤖 Generated with [Claude Code](https://claude.ai/code)