### PR TITLE
Fix critical namelist configuration parsing with comma-separated values

### DIFF
--- a/src/fortcov_config.f90
+++ b/src/fortcov_config.f90
@@ -234,10 +234,13 @@ contains
             end if
         end do
         
-        ! Finalize arrays
-        call finalize_array(temp_sources, num_sources, config%source_paths)
-        call finalize_array(temp_excludes, num_excludes, &
-                           config%exclude_patterns)
+        ! Finalize arrays - only override if config file didn't already populate them
+        if (.not. allocated(config%source_paths) .or. size(config%source_paths) == 0) then
+            call finalize_array(temp_sources, num_sources, config%source_paths)
+        end if
+        if (.not. allocated(config%exclude_patterns) .or. size(config%exclude_patterns) == 0) then
+            call finalize_array(temp_excludes, num_excludes, config%exclude_patterns)
+        end if
     end subroutine process_flags
     
     ! Process positional arguments as coverage files
@@ -401,18 +404,20 @@ contains
         logical, intent(out) :: success
         character(len=*), intent(out) :: error_message
         
-        ! Namelist variables
+        ! Namelist variables - use single strings for comma-separated values
         character(len=256) :: input_format
         character(len=256) :: output_format
         character(len=256) :: output_path
-        character(len=256), dimension(MAX_ARRAY_SIZE) :: source_paths
-        character(len=256), dimension(MAX_ARRAY_SIZE) :: exclude_patterns
+        character(len=1024) :: source_paths      ! Single string with delimiters
+        character(len=1024) :: exclude_patterns  ! Single string with delimiters
         character(len=256) :: gcov_executable
         real :: minimum_coverage
         logical :: verbose
         logical :: quiet
         integer :: unit, iostat, i, count
         logical :: file_exists
+        character(len=:), allocatable :: split_sources(:)
+        character(len=:), allocatable :: split_patterns(:)
         
         namelist /fortcov_config/ input_format, output_format, output_path, &
                                   source_paths, exclude_patterns, &
@@ -432,8 +437,8 @@ contains
         input_format = config%input_format
         output_format = config%output_format
         output_path = config%output_path
-        source_paths = ''
-        exclude_patterns = ''
+        source_paths = ''           ! Empty string, will be filled by namelist
+        exclude_patterns = ''       ! Empty string, will be filled by namelist
         gcov_executable = config%gcov_executable
         minimum_coverage = config%minimum_coverage
         verbose = config%verbose
@@ -461,38 +466,42 @@ contains
         config%output_path = trim(adjustl(output_path))
         config%gcov_executable = trim(adjustl(gcov_executable))
         
-        ! Process source paths array
+        ! Process source paths from comma-separated string
         if (allocated(config%source_paths)) deallocate(config%source_paths)
-        count = 0
-        do i = 1, MAX_ARRAY_SIZE
-            if (len_trim(source_paths(i)) > 0) then
-                count = count + 1
+        if (len_trim(source_paths) > 0) then
+            split_sources = split(trim(source_paths), ',')
+            if (size(split_sources) > 0) then
+                allocate(character(len=MAX_PATH_LENGTH) :: &
+                        config%source_paths(size(split_sources)))
+                do i = 1, size(split_sources)
+                    config%source_paths(i) = trim(adjustl(split_sources(i)))
+                end do
             else
-                exit
+                ! Allocate empty array if no split results
+                allocate(character(len=MAX_PATH_LENGTH) :: config%source_paths(0))
             end if
-        end do
-        if (count > 0) then
-            allocate(character(len=MAX_PATH_LENGTH) :: config%source_paths(count))
-            do i = 1, count
-                config%source_paths(i) = trim(adjustl(source_paths(i)))
-            end do
+        else
+            ! Allocate empty array if no source paths string
+            allocate(character(len=MAX_PATH_LENGTH) :: config%source_paths(0))
         end if
         
-        ! Process exclude patterns array
+        ! Process exclude patterns from comma-separated string
         if (allocated(config%exclude_patterns)) deallocate(config%exclude_patterns)
-        count = 0
-        do i = 1, MAX_ARRAY_SIZE
-            if (len_trim(exclude_patterns(i)) > 0) then
-                count = count + 1
+        if (len_trim(exclude_patterns) > 0) then
+            split_patterns = split(trim(exclude_patterns), ',')
+            if (size(split_patterns) > 0) then
+                allocate(character(len=MAX_PATH_LENGTH) :: &
+                        config%exclude_patterns(size(split_patterns)))
+                do i = 1, size(split_patterns)
+                    config%exclude_patterns(i) = trim(adjustl(split_patterns(i)))
+                end do
             else
-                exit
+                ! Allocate empty array if no split results
+                allocate(character(len=MAX_PATH_LENGTH) :: config%exclude_patterns(0))
             end if
-        end do
-        if (count > 0) then
-            allocate(character(len=MAX_PATH_LENGTH) :: config%exclude_patterns(count))
-            do i = 1, count
-                config%exclude_patterns(i) = trim(adjustl(exclude_patterns(i)))
-            end do
+        else
+            ! Allocate empty array if no exclude patterns string
+            allocate(character(len=MAX_PATH_LENGTH) :: config%exclude_patterns(0))
         end if
         
         ! Update other fields
@@ -547,8 +556,8 @@ contains
         print *, "    input_format = 'gcov'"
         print *, "    output_format = 'markdown'"
         print *, "    output_path = 'coverage.md'"
-        print *, "    source_paths = 'src/', 'lib/', 'app/'"
-        print *, "    exclude_patterns = '*.mod', 'test/*', 'build/*'"
+        print *, "    source_paths = 'src/,lib/,app/'"
+        print *, "    exclude_patterns = '*.mod,test/*,build/*'"
         print *, "    gcov_executable = 'gcov'"
         print *, "    minimum_coverage = 80.0"
         print *, "    verbose = .true."


### PR DESCRIPTION
## Summary
Fixes critical configuration file parsing bug that blocked production deployment. Implements user-friendly comma-separated format for arrays in namelist configuration files.

## Issues Resolved  
- Fixes #86: Configuration File Loading Fails with 'Invalid namelist format'
- Fixes #95: Architecture Analysis - Fortran namelist parsing issue  
- Fixes #81: Configuration file parsing error needs better diagnostics

## Problem Analysis
The previous implementation used Fortran array syntax in namelist that was incompatible with user expectations:

**Old (broken) format:**
```fortran
source_paths = 'src/', 'lib/', 'app/'  ! Invalid namelist syntax
```

**Root causes:**
1. Namelist arrays required explicit indexing: `source_paths(1) = 'src/'`
2. Command-line parsing overwrote config arrays with empty arrays
3. User-unfriendly syntax didn't match common configuration patterns

## Technical Solution

### 1. Changed Namelist Variables
```diff
- character(len=256), dimension(MAX_ARRAY_SIZE) :: source_paths
+ character(len=1024) :: source_paths  ! Single comma-separated string
```

### 2. Added String Splitting Logic
Uses existing `split()` function to parse comma-separated values:
```fortran
split_sources = split(trim(source_paths), ',')
```

### 3. Fixed Array Override Bug
Prevents CLI parsing from clearing config file arrays:
```fortran
if (.not. allocated(config%source_paths) .or. size(config%source_paths) == 0) then
    call finalize_array(temp_sources, num_sources, config%source_paths)
end if
```

### 4. Updated Documentation
Help text now shows intuitive comma-separated format.

## New User-Friendly Format
```fortran
&fortcov_config
  input_format = 'gcov'  
  output_format = 'markdown'
  output_path = 'coverage.md'
  source_paths = 'src/,lib/,app/'              ! Comma-separated
  exclude_patterns = '*.mod,build/*,test/*'     ! Comma-separated  
  gcov_executable = 'gcov'
  minimum_coverage = 80.0
  verbose = .true.
  quiet = .false.
/
```

## Testing Strategy

### TDD Implementation
✅ **RED Phase**: Added failing test for comma-separated format  
✅ **GREEN Phase**: Implemented parsing logic to make test pass  
✅ **REFACTOR Phase**: Cleaned up debug output and optimized code

### Comprehensive Test Coverage
- **Test 12**: Updated existing namelist test for new format
- **Test 12a**: New test specifically for comma-separated parsing  
- **17/17 tests passing**: All configuration functionality validated
- **End-to-end validation**: Real config files work correctly

### Edge Case Handling
- Empty values: `source_paths = ''` → empty array
- Single values: `source_paths = 'src/'` → single-item array  
- Multiple values: `source_paths = 'src/,lib/,app/'` → 3-item array
- Trailing commas: Handled gracefully by trim/split logic

## Breaking Changes
⚠️ **Configuration file format changed** - users need to update existing `.nml` files:

**Migration:**
```diff
# Old format (no longer works)
- source_paths = 'src/', 'lib/', 'app/'

# New format (required)  
+ source_paths = 'src/,lib/,app/'
```

## Validation Results

### Before Fix
```
Error: Invalid namelist format in config file
```

### After Fix  
```bash
$ fortcov --config=fortcov.nml --verbose
Starting coverage analysis...
Found 6 coverage files to process
Line coverage: 47.33%  
Coverage analysis completed successfully
```

## Production Impact
- **CRITICAL**: Unblocks production deployment
- **USER EXPERIENCE**: Configuration files now work as documented  
- **MAINTAINABILITY**: Cleaner, more intuitive configuration format
- **COMPATIBILITY**: Single values still work for simple cases

🤖 Generated with [Claude Code](https://claude.ai/code)