### PR TITLE
fix: CLI quiet flag combinations now work correctly

### DIFF
--- a/src/config_parser.f90
+++ b/src/config_parser.f90
@@ -77,6 +77,25 @@ contains
         success = .true.
         error_message = ""
         
+        ! Check for help/version flags first - these override zero-configuration mode
+        ! But we don't exit early so other flags like --quiet can still be processed
+        do i = 1, size(args)
+            if (len_trim(args(i)) > 0) then
+                if (trim(args(i)) == '--help' .or. trim(args(i)) == '-h') then
+                    config%show_help = .true.
+                else if (trim(args(i)) == '--version' .or. trim(args(i)) == '-V') then
+                    config%show_version = .true.
+                else if (trim(args(i)) == '--quiet' .or. trim(args(i)) == '-q') then
+                    config%quiet = .true.
+                end if
+            end if
+        end do
+        
+        ! If help or version requested, skip zero-config mode and normal parsing
+        if (config%show_help .or. config%show_version) then
+            return
+        end if
+        
         ! Check for zero-configuration mode (no arguments, all empty, or no input sources)
         is_zero_config = (size(args) == 0)
         if (.not. is_zero_config .and. size(args) > 0) then


### PR DESCRIPTION
## Summary
- Fixed CLI argument parsing where --help and --version were ignored when provided with other flags
- Fixed zero-configuration mode incorrectly overriding control flags
- Quiet flag now works correctly with help/version combinations

## Root Cause
The `parse_config` function was triggering zero-configuration mode when `--help` or `--version` were provided because these flags were not considered "input-related arguments". This caused the full coverage analysis to run instead of showing help/version.

## Changes
- Added early detection of --help, --version, and --quiet flags before zero-config check
- These control flags now take precedence over zero-configuration mode
- Help/version with --quiet correctly exit with failure code as designed

## Test Results
- [x] `fortcov --help` shows help and exits with code 0
- [x] `fortcov --quiet --help` shows help and exits with code 1
- [x] `fortcov --version` shows version and exits with code 0  
- [x] `fortcov --quiet --version` shows version and exits with code 1

Fixes #210

🤖 Generated with [Claude Code](https://claude.ai/code)