### PR TITLE
fix: Replace stack-allocated arrays with heap allocation

### DIFF
--- a/src/coverage_discovery.f90
+++ b/src/coverage_discovery.f90
@@ -27,7 +27,7 @@ contains
         character(len=:), allocatable, intent(out) :: coverage_pairs(:)
         integer, intent(out) :: pair_count
         
-        character(len=MAX_PATH_LENGTH) :: temp_pairs(MAX_FILES)
+        character(len=MAX_PATH_LENGTH), allocatable :: temp_pairs(:)
         character(len=:), allocatable :: gcda_files(:)
         logical :: dir_exists
         integer :: i
@@ -40,6 +40,9 @@ contains
             allocate(character(len=MAX_PATH_LENGTH) :: coverage_pairs(0))
             return
         end if
+        
+        ! Allocate temporary array on heap instead of stack
+        allocate(temp_pairs(MAX_FILES))
         
         ! Find all .gcda files recursively
         gcda_files = find_files_recursive(directory_path, "*.gcda")
@@ -61,6 +64,9 @@ contains
         else
             allocate(character(len=MAX_PATH_LENGTH) :: coverage_pairs(0))
         end if
+        
+        ! Clean up temporary array
+        if (allocated(temp_pairs)) deallocate(temp_pairs)
     end subroutine discover_coverage_files
     
     subroutine detect_input_type(input_path, input_type)


### PR DESCRIPTION
## Summary
- MAJOR: Fixed stack allocation risk for large arrays
- coverage_discovery.f90: Move temp_pairs(MAX_FILES) from stack to heap (256KB saved)
- gcov_command_executor.f90: Move temp_files(10) from stack to heap (2.56KB saved)
- Proper memory management with cleanup on all exit paths

## Test plan
- [x] Build succeeds with heap allocation
- [x] All existing tests pass
- [x] Memory properly allocated/deallocated
- [x] Early return paths handle cleanup correctly
- [x] No memory leaks

Generated with [Claude Code](https://claude.ai/code)