### PR TITLE
fix: correct find command syntax in secure deletion test

### DIFF
--- a/test/test_secure_file_deletion_issue_244.f90
+++ b/test/test_secure_file_deletion_issue_244.f90
@@ -562,7 +562,7 @@ contains
         
         ! Check if temp files contain sensitive paths (simplified check)
         call execute_command_line("find /tmp -name 'fortcov_secure_*' -exec grep -l " // &
-                                   "'ssh\\|home\\|root\\|etc' {} \\; >/dev/null 2>&1", exitstat=stat)
+                                   "'ssh\|home\|root\|etc' {} \; >/dev/null 2>&1", exitstat=stat)
         if (stat == 0) then
             sensitive_found = .true.
         end if


### PR DESCRIPTION
## Summary
- Fixed malformed find command syntax that caused test suite hangs
- Corrected escaping in grep pattern within the -exec clause
- Test now executes without "missing argument to -exec" error

## Details
The find command at lines 564-565 in `test/test_secure_file_deletion_issue_244.f90` had incorrect escaping for the grep pattern within the `-exec` clause. The double backslash `\\|` was being incorrectly escaped, causing the shell to receive a malformed command.

Changed from:
```fortran
"'ssh\\|home\\|root\\|etc' {} \; >/dev/null 2>&1"
```

To:
```fortran
"'ssh\|home\|root\|etc' {} \; >/dev/null 2>&1"
```

This allows the shell to properly interpret the pipe characters in the grep regex pattern and the semicolon terminator for the -exec clause.

## Test Results
- Test 7 "Sensitive Data in Temp Files" now executes without syntax error
- Test suite completes without hanging
- No more "find: missing argument to -exec" error messages

## Test Plan
- [x] Run `fpm test --target test_secure_file_deletion_issue_244`
- [x] Verify no "missing argument to -exec" error appears
- [x] Confirm test completes without hanging
- [x] Check that Test 7 executes properly

Fixes #293