### PR TITLE
fix: restore CLI flag functionality and application logic

### DIFF
--- a/src/coverage_analysis.f90
+++ b/src/coverage_analysis.f90
@@ -46,7 +46,7 @@ contains
         end if
         
         ! Handle imported JSON analysis path
-        if (allocated(config%import_file)) then
+        if (allocated(config%import_file) .and. len_trim(config%import_file) > 0) then
             exit_code = perform_imported_json_analysis(config)
             return
         end if


### PR DESCRIPTION
## Summary

- Critical fix for Issue #246: CLI flag parsing completely broken
- All CLI options (--output, --format, --verbose, --quiet) were silently ignored
- Root cause: Application incorrectly entered JSON import mode when import_file was allocated but empty
- Solution: Enhanced import file check to verify both allocation AND content

## Test plan

- [x] CLI flag parsing tests demonstrate correct behavior
- [x] Manual testing of CLI flags shows proper functionality
- [x] All flags now work as documented in help system
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)