### PR TITLE
fix: correct fmp typo to fpm in installation instructions

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,6 @@
 
 ## CURRENT SPRINT (Critical Defects & Architecture)
 ### HIGH (Documentation & Testing Stability)
-- [ ] #252: Typo in installation instructions - fmp vs fpm
 - [ ] #253: Typo in GitLab CI documentation - fmp vs fpm
 - [ ] #254: Typo in troubleshooting section - fmp vs fpm
 - [ ] #262: Typo in troubleshooting.md - 'fmp' should be 'fpm'
@@ -20,7 +19,7 @@
 *All Sprint 1 auto-discovery features implemented and merged*
 
 ## DOING (Current Work)
-*No active work - Sprint 1 completed*
+- [x] #252: Typo in installation instructions - fmp vs fpm (branch: fix-installation-typo-252)
 
 ## DONE (Completed Work)
 - [x] #277: Add auto-discovery of test build and gcov processing (completed in PR #334)

--- a/PLAY_INFRASTRUCTURE_STATUS.md
+++ b/PLAY_INFRASTRUCTURE_STATUS.md
@@ -13,7 +13,7 @@
 
 **Build Configuration**: FPM-based project
 - Build system: `fpm.toml` properly configured
-- Build command: `fmp build` ✅ SUCCESSFUL (100% compile success)
+- Build command: `fpm build` ✅ SUCCESSFUL (100% compile success)
 - 62 Fortran source files + 4 C files compiled successfully
 - Library and executable built without errors
 
@@ -25,7 +25,7 @@
 ## Test Infrastructure Status ⚠️ DEGRADED
 
 **Test Execution Issues Identified**:
-- Command: `fmp test` experiences timeout and repetitive failures
+- Command: `fpm test` experiences timeout and repetitive failures
 - Symptoms: 
   - `find: missing argument to '-exec'` errors
   - Multiple `STOP 0` and `STOP 1` signals
@@ -34,7 +34,7 @@
 
 **Test Files Analysis**:
 - Main test runner: `/test/check.f90` (basic placeholder)
-- 14 specific test files defined in `fmp.toml`
+- 14 specific test files defined in `fpm.toml`
 - Several disabled test files (*.disabled)
 - Mix of Fortran and shell script tests
 

--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -52,10 +52,10 @@ fpm test
 fpm test --flag "-fprofile-arcs -ftest-coverage"
 
 # Clean build artifacts (preserving necessary files)
-fmp clean --skip
+fpm clean --skip
 
 # Run the main application
-fmp run
+fpm run
 ```
 
 ## CRITICAL: Fork Bomb Prevention
@@ -63,7 +63,7 @@ fmp run
 **🚨 MANDATORY SAFETY RULES - NEVER VIOLATE:**
 
 1. **NO TEST-WITHIN-TEST CALLS**:
-   - Tests MUST NEVER call `fpm test` or `fmp test` (causes infinite recursion)
+   - Tests MUST NEVER call `fpm test` (causes infinite recursion)
    - Shell scripts in test/ MUST NOT execute the test runner
    - Any test calling the test runner creates a fork bomb
 

--- a/doc/developer/development-guide.md
+++ b/doc/developer/development-guide.md
@@ -268,7 +268,7 @@ call process_file_streaming(filename, buffer_size=4096)
 # Complete testing workflow
 fpm build
 fpm test
-fmp test --flag "-fprofile-arcs -ftest-coverage"
+fpm test --flag "-fprofile-arcs -ftest-coverage"
 gcov src/*.f90
 fortcov --source=src --fail-under=90 --output=coverage.md
 ```

--- a/doc/developer/testing.md
+++ b/doc/developer/testing.md
@@ -84,7 +84,7 @@ fortcov --source=test --output=test-coverage.md
 
 ```bash
 # Run performance benchmarks
-fmp test test_performance_benchmarks
+fpm test test_performance_benchmarks
 
 # Profile test execution
 fpm build --flag "-pg"
@@ -528,9 +528,9 @@ Each major feature should have a test plan:
 
 ### Problem Overview
 
-FortCov tests were causing infinite loops when test scripts recursively called `fmp test` within the test suite execution. This created "fork bombs" where:
+FortCov tests were causing infinite loops when test scripts recursively called `fpm test` within the test suite execution. This created "fork bombs" where:
 
-1. **Root cause**: Test files calling `fmp test` within their execution
+1. **Root cause**: Test files calling `fpm test` within their execution
 2. **Symptom**: Test suite hanging indefinitely or taking 3+ minutes 
 3. **Impact**: CI/CD pipelines blocked, development workflow disrupted
 

--- a/doc/implementation/SYSTEM_TEST_DESIGN.md
+++ b/doc/implementation/SYSTEM_TEST_DESIGN.md
@@ -85,7 +85,7 @@ For reliability, the system maintains a curated list of validated commit pairs:
 1. Git Checkout & Build Phase
    ├── git checkout <baseline_sha>
    ├── fpm build --flag "-fprofile-arcs -ftest-coverage"
-   ├── fmp test --flag "-fprofile-arcs -ftest-coverage" 
+   ├── fpm test --flag "-fprofile-arcs -ftest-coverage" 
    └── fortcov --export-json=baseline.json
 
 2. Coverage Data Collection Phase

--- a/doc/user/getting-started.md
+++ b/doc/user/getting-started.md
@@ -5,7 +5,7 @@
 ## Prerequisites Check
 
 ```bash
-which gfortran gcov fmp fortcov  # All must be installed
+which gfortran gcov fpm fortcov  # All must be installed
 ```
 
 ## Quick Tutorial
@@ -39,7 +39,7 @@ end program
 EOF
 
 # 4. Generate coverage
-fmp test --flag "-fprofile-arcs -ftest-coverage"
+fpm test --flag "-fprofile-arcs -ftest-coverage"
 find build -name "*.gcda" | xargs dirname | sort -u | while read dir; do
   gcov --object-directory="$dir" "$dir"/*.gcno 2>/dev/null || true
 done

--- a/doc/user/installation.md
+++ b/doc/user/installation.md
@@ -19,7 +19,7 @@ sudo cp build/gfortran_*/app/fortcov /usr/local/bin/
 xcode-select --install
 brew install gcc fortran-lang/tap/fpm
 git clone https://github.com/lazy-fortran/fortcov.git
-cd fortcov && fmp build --profile release
+cd fortcov && fpm build --profile release
 sudo cp build/gfortran_*/app/fortcov /usr/local/bin/
 ```
 

--- a/doc/user/troubleshooting.md
+++ b/doc/user/troubleshooting.md
@@ -27,7 +27,7 @@ rm -rf build/ && fpm build --profile release
 **Memory Errors (fixed in v2.0+):**
 ```bash
 # Update to latest version
-git pull && fmp build --profile release
+git pull && fpm build --profile release
 sudo cp build/gfortran_*/app/fortcov /usr/local/bin/
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -147,7 +147,7 @@ mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
 # Setup test project
-cat > fmp.toml << 'EOF'  
+cat > fpm.toml << 'EOF'  
 name = "test_project"
 version = "0.1.0"
 EOF
@@ -223,7 +223,7 @@ mv test/problematic_test.sh test/problematic_test.sh.FORK_BOMB_DISABLED
 # DISABLED: This test causes infinite recursion by calling "fpm test"
 # TODO: Rewrite to test functionality directly without recursive calls
 #
-# Original problem: Line 45 calls "fmp test" which re-runs this script
+# Original problem: Line 45 calls "fpm test" which re-runs this script
 # Fix needed: Replace fpm test with direct binary execution
 ```
 
@@ -282,7 +282,7 @@ If you encounter an infinite loop:
 Before adding new tests, verify:
 
 - [ ] Test does not call `fpm test` 
-- [ ] Test does not call `fmp run fortcov` in a way that triggers test execution
+- [ ] Test does not call `fpm run fortcov` in a way that triggers test execution
 - [ ] Shell scripts test binaries directly
 - [ ] Fortran tests focus on module functionality  
 - [ ] Integration tests use isolated environments

--- a/examples/build_systems/ci_cd/github_actions/fortcov_coverage_matrix.yml
+++ b/examples/build_systems/ci_cd/github_actions/fortcov_coverage_matrix.yml
@@ -72,7 +72,7 @@
         start_time=$(date +%s)
         
         # Create mock coverage analysis for demonstration
-        # In real usage: fmp run fortcov -- --source=src --output=coverage.html
+        # In real usage: fpm run fortcov -- --source=src --output=coverage.html
         cat > coverage-${{ matrix.compiler }}-${{ matrix.os }}.html << 'EOF'
         <!DOCTYPE html>
         <html>

--- a/src/zero_configuration_manager.f90
+++ b/src/zero_configuration_manager.f90
@@ -261,7 +261,7 @@ contains
         character(len=:), allocatable :: temp_files(:)
         
         ! Priority 1: FPM build structure
-        temp_files = discover_fmp_gcda_files()
+        temp_files = discover_fpm_gcda_files()
         if (allocated(temp_files) .and. size(temp_files) > 0) then
             gcda_files = temp_files
             return
@@ -279,7 +279,7 @@ contains
         gcda_files = temp_files
     end function discover_gcda_files_priority
     
-    function discover_fmp_gcda_files() result(gcda_files)
+    function discover_fpm_gcda_files() result(gcda_files)
         !! Discover .gcda files in FPM build structure
         character(len=:), allocatable :: gcda_files(:)
         character(len=:), allocatable :: temp_files(:), app_files(:), test_files(:)
@@ -320,7 +320,7 @@ contains
         else
             allocate(character(len=256) :: gcda_files(0))
         end if
-    end function discover_fmp_gcda_files
+    end function discover_fpm_gcda_files
     
     function discover_cmake_gcda_files() result(gcda_files)
         !! Discover .gcda files in CMake build structure  

--- a/test/test_build_discovery.f90
+++ b/test/test_build_discovery.f90
@@ -15,7 +15,7 @@ program test_build_discovery
     write(output_unit, '(A)') 'Running test build discovery tests...'
     write(output_unit, '(A)') ''
 
-    call test_auto_discover_test_build_with_fmp()
+    call test_auto_discover_test_build_with_fpm()
     call test_auto_discover_test_build_with_cmake()
     call test_auto_discover_test_build_with_make()
     call test_auto_discover_test_build_with_meson()
@@ -32,7 +32,7 @@ program test_build_discovery
 
 contains
 
-    subroutine test_auto_discover_test_build_with_fmp()
+    subroutine test_auto_discover_test_build_with_fpm()
         !! Given an FPM project structure
         !! When auto_discover_test_build is called
         !! Then it should detect FPM and configure test command
@@ -54,7 +54,7 @@ contains
         call assert_true(len_trim(result%test_command) > 0, 'Test command configured')
         
         call cleanup_mock_project()
-    end subroutine test_auto_discover_test_build_with_fmp
+    end subroutine test_auto_discover_test_build_with_fpm
 
     subroutine test_auto_discover_test_build_with_cmake()
         !! Given a CMake project structure


### PR DESCRIPTION
## Summary
- Fixed critical typos throughout documentation where 'fmp' was incorrectly used instead of 'fpm'
- Corrected function names in source and test code that used 'fmp' naming convention
- Ensures users can successfully follow installation and usage instructions

## Changes Made

### Documentation Files Fixed
- `doc/user/installation.md` - macOS installation command
- `doc/user/troubleshooting.md` - Update command in memory errors section  
- `doc/user/getting-started.md` - Prerequisites check and tutorial commands
- `doc/developer/development-guide.md` - Test workflow command
- `doc/developer/testing.md` - Performance testing commands and infinite loop documentation
- `doc/CLAUDE.md` - Clean build and run commands, fork bomb prevention rules
- `doc/implementation/SYSTEM_TEST_DESIGN.md` - Test execution pipeline
- `docs/TESTING.md` - FPM configuration file creation and test documentation
- `PLAY_INFRASTRUCTURE_STATUS.md` - Build and test command references

### Code Files Fixed
- `src/zero_configuration_manager.f90` - Renamed `discover_fmp_gcda_files()` to `discover_fpm_gcda_files()`
- `test/test_build_discovery.f90` - Renamed `test_auto_discover_test_build_with_fmp()` to `test_auto_discover_test_build_with_fpm()`

### Example Files Fixed
- `examples/build_systems/ci_cd/github_actions/fortcov_coverage_matrix.yml` - Comment showing real usage example

## Impact
These typos were preventing users from successfully following installation and usage instructions, as 'fmp' is not a valid command. The correct Fortran Package Manager command is 'fpm'. This fix ensures documentation accuracy and prevents user confusion.

## Testing
- Verified all changes compile successfully with `fpm build --profile release`
- Confirmed no 'fmp' typos remain in critical documentation paths
- Function renames in source code maintain compatibility

Fixes #252

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>