### PR TITLE
fix: resolve issue #266 - obsolete test directory change concern

### DIFF
--- a/INVESTIGATION_266.md
+++ b/INVESTIGATION_266.md
@@ -1,0 +1,40 @@
+# Investigation Report: Issue #266 - Fix ineffective directory change in test_zero_configuration_issue_249
+
+## Issue Summary
+Issue #266 reported ineffective directory change using `execute_command_line("cd " // trim(test_dir))` on lines 43 and 94 in `test/test_zero_configuration_issue_249.f90`.
+
+## Investigation Results
+
+### File System Search
+1. **Target file not found**: `test/test_zero_configuration_issue_249.f90` does not exist
+2. **Similar file found**: `test/test_issue_249.f90` exists as consolidated test suite for Issue #249
+3. **Pattern verification**: No current Fortran test files contain the problematic `execute_command_line("cd "` pattern
+
+### Current State Analysis
+- Shell scripts with `cd` usage exist but are disabled (`.FORK_BOMB_DISABLED` extension)
+- The existing `test/test_issue_249.f90` does not use `execute_command_line` for directory changes
+- Directory operations use proper Fortran intrinsics and safe mechanisms:
+  - `safe_mkdir()` for directory creation
+  - `rmdir()` with proper validation and escaping
+  - File operations with full paths instead of relying on working directory changes
+
+### Historical Context
+The issue was reported from PR #261 review, suggesting the problematic pattern may have been:
+1. Fixed by using proper Fortran directory handling
+2. Removed during code consolidation/cleanup
+3. Replaced with safer alternatives in the current implementation
+
+### Code Quality Assessment
+Current `test/test_issue_249.f90` shows good practices:
+- Uses `safe_mkdir()` with error handling (lines 206-211)
+- Creates files with full paths instead of relying on directory changes (line 214)
+- Safe directory cleanup with validation (lines 250-298)
+- No reliance on shell `cd` commands that don't affect the Fortran process
+
+## Conclusion
+Issue #266 appears to be **obsolete**. The reported problematic code pattern does not exist in the current codebase:
+- Target file `test/test_zero_configuration_issue_249.f90` not found
+- No ineffective `execute_command_line("cd ")` patterns found in any test files
+- Existing test infrastructure uses proper Fortran directory handling mechanisms
+
+**Recommendation**: Close issue as resolved/obsolete - the problem has been addressed through proper implementation.


### PR DESCRIPTION
## Summary
- Investigation confirms issue #266 is obsolete
- Target file `test/test_zero_configuration_issue_249.f90` does not exist  
- No ineffective `execute_command_line("cd ")` patterns found in current codebase
- Existing test infrastructure uses proper Fortran directory handling

## Investigation Results
- Comprehensive file search confirms problematic pattern removed
- Current `test/test_issue_249.f90` uses safe directory operations
- Shell scripts with `cd` usage are disabled (`.FORK_BOMB_DISABLED`)
- Code quality assessment shows proper implementation patterns

## Resolution
Issue has been addressed through proper implementation - no code changes needed.

Generated with [Claude Code](https://claude.ai/code)