### PR TITLE
fix: preserve user-specified terminal output format

### DIFF
--- a/src/config_defaults.f90
+++ b/src/config_defaults.f90
@@ -189,10 +189,7 @@ contains
             config%source_paths(1) = "."
         end if
 
-        ! Set HTML output if not explicitly set
-        if (config%output_format == "terminal") then
-            config%output_format = "html"
-        end if
+        ! Terminal format is valid and supported - no conversion needed
 
         ! Set default output path if not set
         if (len_trim(config%output_path) == 0) then


### PR DESCRIPTION
## Summary
- Fixed output format mapping bug where `--format=terminal` incorrectly displayed as `Format: html`
- Removed incorrect format conversion logic that was overriding user-specified terminal format
- Terminal format is fully supported and should be preserved when explicitly requested

## Test Results
**Before Fix:**
```bash
$ fortcov --format=terminal --verbose
Format: html  # ❌ Wrong!
```

**After Fix:**
```bash  
$ fortcov --format=terminal --verbose
Format: terminal  # ✅ Correct!
```

## Verification
- ✅ `--format=terminal` → `Format: terminal`
- ✅ `--format=json` → `Format: json` 
- ✅ `--format=html` → `Format: html`
- ✅ Default (no format) → `Format: markdown`
- ✅ Zero-config workflow tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)