### PR TITLE
fix: improve error message for invalid command line options

### DIFF
--- a/src/config_parser_utils.f90
+++ b/src/config_parser_utils.f90
@@ -229,14 +229,24 @@ contains
         logical :: requires_value
 
         select case (trim(flag))
+        ! Flags that do NOT require values
         case ("--help", "-h", "--version", "-V", "--verbose", "-v", &
               "--quiet", "-q", "--validate", "--keep-gcov-files", &
               "--tui", "--strict", "--include-unchanged", &
               "--auto-discovery", "--no-auto-discovery", &
               "--auto-test", "--no-auto-test")
             requires_value = .false.
-        case default
+        ! Flags that DO require values
+        case ("--source", "-s", "--exclude", "-e", "--include", "-i", &
+              "--output", "-o", "--format", "-f", "--config", "-c", &
+              "--import", "--gcov-executable", "--gcov-args", &
+              "--minimum", "-m", "--threshold", "--fail-under", &
+              "--threads", "-t", "--diff", "--diff-threshold", &
+              "--test-timeout")
             requires_value = .true.
+        ! Unknown flags do not require values (will be caught as invalid later)
+        case default
+            requires_value = .false.
         end select
 
     end function flag_requires_value


### PR DESCRIPTION
## Summary
- Fixed confusing error message for invalid command line options
- Changed misleading "Missing value for flag: --invalid-option" to clear "Unknown flag: --invalid-option"
- Restructured flag validation logic to properly distinguish between invalid flags and valid flags missing values

## Root Cause Analysis
The `flag_requires_value()` function was incorrectly assuming all unknown flags require values, causing:
1. Unknown flags like `--invalid-option` → `flag_requires_value()` returns `true`
2. Parser looks for missing value → shows "Missing value for flag: --invalid-option"
3. Never reaches the "Unknown flag" validation logic

## Solution
Modified `flag_requires_value()` to explicitly list:
- ✅ Known flags that DO require values (--source, --format, --output, etc.)
- ✅ Known flags that do NOT require values (--verbose, --help, --tui, etc.)  
- ✅ Unknown flags default to NOT requiring values → properly caught as "Unknown flag"

## Test Results
**Before Fix:**
```bash
$ fortcov --invalid-option
Error: Missing value for flag: --invalid-option  # ❌ Confusing!
```

**After Fix:**
```bash
$ fortcov --invalid-option  
Error: Unknown flag: --invalid-option  # ✅ Clear and accurate!
```

## Verification
- ✅ Invalid flags → "Unknown flag: --invalid-option"
- ✅ Valid flags missing values → "Missing value for flag: --format"  
- ✅ Valid flags with values → Works normally
- ✅ Boolean flags → Works normally
- ✅ All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)