### PR TITLE
refactor: consolidate duplicate real_to_string functions

### DIFF
--- a/src/system_diff_converter.f90
+++ b/src/system_diff_converter.f90
@@ -4,6 +4,7 @@ module system_diff_converter
     use string_utils
     use json_parser_utilities
     use xml_utilities
+    use string_utilities, only: real_to_string
     implicit none
     private
     

--- a/src/xml_utilities.f90
+++ b/src/xml_utilities.f90
@@ -1,6 +1,6 @@
 module xml_utilities
     use coverage_model
-    use string_utilities, only: int_to_string
+    use string_utilities, only: int_to_string, real_to_string
     implicit none
     private
     
@@ -15,7 +15,6 @@ module xml_utilities
     public :: parse_lines_from_class
     public :: extract_line_attributes
     public :: get_current_timestamp
-    public :: real_to_string
     public :: int_to_string
     public :: get_directory_path
     public :: get_base_name
@@ -410,16 +409,6 @@ contains
             values(5), ':', values(6), ':', values(7)
             
     end function get_current_timestamp
-    
-    function real_to_string(value) result(str)
-        real, intent(in) :: value
-        character(len=20) :: temp_str
-        character(len=:), allocatable :: str
-        
-        write(temp_str, '(F0.6)') value
-        str = trim(adjustl(temp_str))
-        
-    end function real_to_string
     
     function get_directory_path(filename) result(dir_path)
         character(len=*), intent(in) :: filename


### PR DESCRIPTION
## Summary
- Remove duplicate `real_to_string` implementation from `xml_utilities.f90`
- Update `xml_utilities` to import `real_to_string` from `string_utilities`
- Fix `system_diff_converter.f90` imports to use consolidated version
- Maintain functional equivalence for XML attributes while eliminating code duplication

## Test plan
- [x] Build project successfully - no compilation errors
- [x] Verify executable functionality with `--help` command
- [x] Confirm only one `real_to_string` implementation remains in codebase
- [x] Validate that all modules correctly import from `string_utilities`

🤖 Generated with [Claude Code](https://claude.ai/code)