### PR TITLE
cleanup: remove unused sanitize_filename function

### DIFF
--- a/src/string_utils.f90
+++ b/src/string_utils.f90
@@ -9,7 +9,6 @@ module string_utils
     public :: split
     public :: trim_string
     public :: validate_string_input
-    public :: sanitize_filename
     public :: is_safe_path
     public :: to_lower
     public :: matches_pattern
@@ -244,33 +243,6 @@ contains
         end do
     end function validate_string_input
 
-    ! Security: Sanitize filename by removing dangerous characters
-    function sanitize_filename(filename) result(safe_filename)
-        character(len=*), intent(in) :: filename
-        character(len=:), allocatable :: safe_filename
-        character(len=len(filename)) :: temp_filename
-        integer :: i, j
-        
-        temp_filename = ''
-        j = 1
-        
-        do i = 1, len_trim(filename)
-            ! Keep alphanumeric, period, underscore, hyphen, forward slash
-            if (verify(filename(i:i), &
-                'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/') &
-                == 0) then
-                temp_filename(j:j) = filename(i:i)
-                j = j + 1
-            end if
-        end do
-        
-        safe_filename = trim(temp_filename)
-        
-        ! Security: Enforce maximum length
-        if (len(safe_filename) > 1024) then
-            safe_filename = safe_filename(1:1024)
-        end if
-    end function sanitize_filename
 
     ! Security: Check if path is safe (no directory traversal)
     function is_safe_path(path) result(is_safe)


### PR DESCRIPTION
## Summary
- Remove unused sanitize_filename function from string_utils module (26 lines of dead code)
- Function provided filename sanitization by removing dangerous characters but had zero usage
- Clean function-level dead code elimination maintaining all functionality
- Reduced public API surface of string_utils module

## Function Analysis
- **Purpose**: Sanitized filenames by keeping only alphanumeric, period, underscore, hyphen, forward slash
- **Security**: Enforced 1024 character maximum length
- **Usage**: Zero calls found anywhere in codebase (comprehensive grep verification)
- **Export**: Removed from public procedure declarations

## Test plan
- [x] Build project successfully - no compilation errors
- [x] Verify executable functionality with `--help` command
- [x] Confirm function was completely unused (comprehensive grep verification)
- [x] Validate no calls or dependencies on removed function

🤖 Generated with [Claude Code](https://claude.ai/code)