### PR TITLE
fix: restore CLI and config functionality - fixes #437

### DIFF
--- a/src/config_argument_detector.f90
+++ b/src/config_argument_detector.f90
@@ -38,6 +38,7 @@ contains
             ! Check for input-related flags
             if (flag_part == "--source" .or. flag_part == "-s" .or. &
                 flag_part == "--import" .or. &
+                flag_part == "--config" .or. flag_part == "-c" .or. &
                 flag_part == "--gcov-executable" .or. &
                 flag_part == "--gcov-args" .or. &
                 flag_part == "--include" .or. flag_part == "-i" .or. &
@@ -92,7 +93,8 @@ contains
                 flag_part == "--include-unchanged" .or. &
                 flag_part == "--threshold" .or. flag_part == "-m" .or. &
                 flag_part == "--minimum" .or. &
-                flag_part == "--strict") then
+                flag_part == "--strict" .or. &
+                flag_part == "--validate") then
                 has_output_args = .true.
                 return
             end if


### PR DESCRIPTION
## Summary
Fixed major functional regressions in fortcov's CLI and configuration handling that were causing validation failures and preventing proper use of the tool.

## Changes
- Added `--validate` flag to output-related arguments for proper zero-config detection
- Added `--config` and `-c` flags to input-related arguments to prevent incorrect zero-config mode triggering
- Fixed issue where `--validate` alone would fail but `--validate --verbose` would succeed
- Fixed issue where config files were not being properly recognized and parsed
- Ensures zero-configuration mode only triggers when truly no arguments are provided
- Prevents "Configuration validation failed" errors with valid flag combinations

## Testing
- ✅ `fortcov --validate` now works correctly
- ✅ `fortcov --config file.conf` properly loads configuration
- ✅ `fortcov --source src/` works without triggering zero-config mode
- ✅ `fortcov --tui` launches terminal UI properly
- ✅ Zero-config mode (`fortcov` with no args) still works correctly
- ✅ CLI flag tests (test_cli_flag_parsing_issue_231) now pass
- ✅ Config auto-discovery tests pass

## Fixes #437
Resolves the major functional regression where core CLI and config functionality was completely broken.