### PR TITLE
docs: fix CLI parameter inconsistencies in user documentation

### DIFF
--- a/doc/user/examples.md
+++ b/doc/user/examples.md
@@ -45,7 +45,7 @@ fpm test --flag "-fprofile-arcs -ftest-coverage"
 find build -name "*.gcda" | while read gcda_file; do
   gcov -b "$gcda_file" 2>/dev/null || true
 done
-fortcov --source=. --output=coverage.md
+fortcov --source . --output coverage.md
 ```
 
 **Expected output:**
@@ -64,7 +64,7 @@ fpm test --flag "-fprofile-arcs -ftest-coverage"
 find build -name "*.gcda" | while read gcda_file; do
   gcov -b "$gcda_file" 2>/dev/null || true
 done
-fortcov --source=.
+fortcov --source .
 ```
 
 **CMake:**
@@ -72,7 +72,7 @@ fortcov --source=.
 set(CMAKE_Fortran_FLAGS_TESTING "-fprofile-arcs -ftest-coverage")
 add_custom_target(coverage
     COMMAND gcov *.gcno
-    COMMAND fortcov --source=${CMAKE_SOURCE_DIR}
+    COMMAND fortcov --source ${CMAKE_SOURCE_DIR}
 )
 ```
 
@@ -80,7 +80,7 @@ add_custom_target(coverage
 ```makefile
 coverage: test
 	gcov $(SOURCES) 
-	fortcov --source=. --output=coverage.md
+	fortcov --source . --output coverage.md
 ```
 
 ## CI/CD Integration
@@ -92,7 +92,7 @@ coverage: test
     find build -name "*.gcda" | while read gcda_file; do
       gcov -b "$gcda_file" 2>/dev/null || true
     done
-    fortcov --source=. --fail-under=80 --output-format=json --output=coverage.json
+    fortcov --source . --fail-under 80 --format json --output coverage.json
 ```
 
 **GitLab CI:**
@@ -101,7 +101,7 @@ coverage:
   script:
     - fpm test --flag "-fprofile-arcs -ftest-coverage" 
     - find build -name "*.gcda" | while read gcda_file; do gcov -b "$gcda_file" 2>/dev/null || true; done
-    - fortcov --source=. --output-format=xml --output=coverage.xml --fail-under=80
+    - fortcov --source . --format xml --output coverage.xml --fail-under 80
   artifacts:
     reports:
       coverage_report:

--- a/doc/user/getting-started.md
+++ b/doc/user/getting-started.md
@@ -43,7 +43,7 @@ fpm test --flag "-fprofile-arcs -ftest-coverage"
 find build -name "*.gcda" | xargs dirname | sort -u | while read dir; do
   gcov --object-directory="$dir" "$dir"/*.gcno 2>/dev/null || true
 done
-fortcov --source=. --output=coverage.md  # Creates coverage report
+fortcov --source . --output coverage.md  # Creates coverage report
 ```
 
 ## Next Steps

--- a/doc/user/troubleshooting.md
+++ b/doc/user/troubleshooting.md
@@ -34,12 +34,12 @@ sudo cp build/gfortran_*/app/fortcov /usr/local/bin/
 **Security Messages:**
 ```bash
 # Use clean paths
-fortcov --source=src  # ✅ Good
-# fortcov --source="src;rm -rf /"  # ❌ Blocked
+fortcov --source src  # ✅ Good
+# fortcov --source "src;rm -rf /"  # ❌ Blocked
 
 # Avoid special characters  
-fortcov --output=coverage.md  # ✅ Good
-# fortcov --output="report|danger"  # ❌ Blocked
+fortcov --output coverage.md  # ✅ Good
+# fortcov --output "report|danger"  # ❌ Blocked
 ```
 
 **No Coverage Data:**

--- a/doc/user/usage-guide.md
+++ b/doc/user/usage-guide.md
@@ -9,13 +9,13 @@
 fortcov
 
 # Traditional usage  
-fortcov --source=src --output=coverage.md
+fortcov --source src --output coverage.md
 
 # CI/CD usage
-fortcov --fail-under=80 --quiet
+fortcov --fail-under 80 --quiet
 
 # Configuration file
-fortcov --config=fortcov.nml
+fortcov --config fortcov.nml
 ```
 
 ## Advanced Options


### PR DESCRIPTION
## Summary
This PR addresses Issue #423 by fixing CLI parameter inconsistencies throughout the user documentation.

## Parameter Fixes

### Format Parameter
- ✅ Changed `--output-format=json` to `--format json` (matches `fortcov --help`)
- ✅ Changed `--output-format=xml` to `--format xml`

### Parameter Syntax
- ✅ Changed equals signs to spaces for consistency: 
  - `--source=.` → `--source .`
  - `--output=file.md` → `--output file.md`
  - `--fail-under=80` → `--fail-under 80`

## Files Fixed
- **doc/user/examples.md**: GitHub Actions and GitLab CI examples
- **doc/user/getting-started.md**: Basic coverage command
- **doc/user/usage-guide.md**: Command reference examples  
- **doc/user/troubleshooting.md**: Security examples

## Verification
All changed parameters now match the exact syntax from `fortcov --help` output:

```bash
$ fortcov --help
...
  -f, --format FORMAT       Output format:
                            terminal (default), json, xml, html, lcov, cobertura
  -o, --output PATH         Output file path
  -m, --minimum PERCENT     Set minimum coverage percentage
  --fail-under PERCENT      Fail if coverage is below threshold
...
```

## Impact
- ✅ Copy-paste examples from documentation now work correctly
- ✅ Users get consistent parameter syntax across all documentation
- ✅ No more confusing error messages from incorrect parameters
- ✅ CLI interface appears consistent and professional

Generated with [Claude Code](https://claude.ai/code)