### PR TITLE
fix: remove non-existent directory references from README

### DIFF
--- a/examples/build_systems/README.md
+++ b/examples/build_systems/README.md
@@ -27,12 +27,6 @@ Each subdirectory contains a complete, working example with:
 ### Specialized Environments
 - **[docker/](docker/)** - Container-based coverage workflows
 - **[hpc/](hpc/)** - HPC and SLURM integration patterns
-- **[ide/](ide/)** - IDE integration examples (VS Code, CLion)
-
-### Advanced Patterns
-- **[cross_platform/](cross_platform/)** - Multi-compiler, multi-OS examples
-- **[performance/](performance/)** - Large project optimization patterns
-- **[parallel/](parallel/)** - MPI and parallel coverage collection
 
 ## Testing Examples
 


### PR DESCRIPTION
## Summary
Fixes README directory references that pointed to non-existent directories and features.

## Changes Made
- ✅ Removed `ide/` directory reference (VS Code, CLion integration examples)
- ✅ Removed `cross_platform/` directory reference (multi-compiler, multi-OS examples)  
- ✅ Removed `performance/` directory reference (large project optimization patterns)
- ✅ Removed `parallel/` directory reference (MPI and parallel coverage collection)

## Verification
- All remaining directory references now point to existing directories:
  - ✅ `fpm/`, `cmake/`, `make/`, `meson/` - build systems
  - ✅ `ci_cd/github_actions/`, `ci_cd/gitlab_ci/`, `ci_cd/jenkins/` - CI/CD platforms
  - ✅ `docker/`, `hpc/` - specialized environments
- ✅ `test_all_examples.sh` correctly exists and is executable (contrary to issue claim)

## Impact
- Users following documentation will no longer encounter 404-style errors
- Documentation now accurately reflects available features
- Build system integration guide is consistent with actual codebase

fixes #422