### PR TITLE
fix: correct non-functional command examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ Coverage Summary:
 **Zero-configuration (recommended):**
 ```bash
 fpm test --flag "-fprofile-arcs -ftest-coverage"
-fortcov  # Auto-discovers and generates coverage.md
+fortcov  # Auto-discovers coverage files and shows terminal output
 ```
 
 **Manual file specification:**
 ```bash
-fortcov *.gcov --output coverage.md
-fortcov --source src --output coverage.html --format html
-fortcov --import coverage.json --format lcov --output coverage.info
+fortcov *.gcov  # Analyze gcov files with terminal output
 ```
+
+**Note**: File output formats (--output, --format) are currently affected by issue #396 and show "would be generated" instead of creating actual files. Terminal output works correctly.
 
 **CI/CD integration:**
 ```bash
@@ -94,7 +94,7 @@ fortcov --minimum 80 --fail-under 80  # Fail if coverage < 80%
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature-name`
 3. Make changes and add tests
-4. Run the test suite: `fmp test`
+4. Run the test suite: `fpm test`
 5. Submit a pull request
 
 For detailed contribution guidelines, see [`doc/developer/development-guide.md`](doc/developer/development-guide.md).


### PR DESCRIPTION
## Summary
Fixes README command examples that don't work due to underlying tool issues.

## Changes Made
- **Fix typo**: `fmp` → `fpm` in contributing section
- **Update examples**: Show working terminal output instead of broken file output
- **Add transparency note**: Document issue #396 affecting file output formats  
- **Remove misleading examples**: Eliminated claims about file generation that don't work
- **Ensure functionality**: All documented examples now actually work as shown

## Before/After Examples

### Before (Non-functional)
```bash
fortcov *.gcov --output coverage.md        # Says "would be generated" but doesn't create file
fortcov --source src --output coverage.html --format html  # Same issue
```

### After (Functional)  
```bash
fortcov *.gcov  # Analyze gcov files with terminal output (actually works)
```

## Impact
- **User Experience**: Users can now follow documentation and get working results
- **Onboarding**: New users won't be confused by broken examples
- **Transparency**: Clear about current limitations while providing working alternatives  
- **Maintainability**: Documentation matches actual tool behavior

## Verification
✅ Tested all updated examples - they work as documented
✅ Terminal output functions correctly
✅ Note about file output issues provides clear guidance
✅ Contributing section uses correct `fpm` command

fixes #397