### PR TITLE
fix: correct broken gcov workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ cd your-fortran-project
 fpm test --flag "-fprofile-arcs -ftest-coverage"
 fortcov
 
-# Manual mode with specific files
-gcov src/*.f90
-fortcov --source . --exclude build/* --exclude test/* --output coverage.md
+# Manual gcov file generation (if needed)
+fpm test --flag "-fprofile-arcs -ftest-coverage"
+find . -name "*.gcda" | while read gcda_file; do
+  gcov -b "$gcda_file" --object-directory=$(dirname "$gcda_file") 2>/dev/null || true
+done
+fortcov *.gcov
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary
Fixes the broken gcov workflow documentation that doesn't generate .gcov files as documented in issue #431.

## Problem Analysis
The existing README showed this broken workflow:
```bash
fpm test --flag "-fprofile-arcs -ftest-coverage"
gcov src/*.f90  # ❌ BROKEN - cannot find .gcno/.gcda files
```

**Root Cause**: `gcov src/*.f90` looks for .gcno/.gcda files in the `src/` directory, but these files are actually created in build directories or project root depending on FPM's current state.

## Solution Implemented
Replaced the broken command with a robust find-based approach:
```bash
fpm test --flag "-fprofile-arcs -ftest-coverage"
find . -name "*.gcda" | while read gcda_file; do
  gcov -b "$gcda_file" --object-directory=$(dirname "$gcda_file") 2>/dev/null || true
done
fortcov *.gcov
```

## Key Improvements
- ✅ **Finds actual .gcda files** wherever they exist (build dirs, root, etc.)
- ✅ **Proper path resolution** using `--object-directory` flag
- ✅ **Error handling** with `|| true` for graceful failures
- ✅ **Works with any build state** (clean builds, incremental, etc.)
- ✅ **Generates actual .gcov files** instead of failing silently

## Before/After Behavior

### Before (Broken)
```
$ gcov src/*.f90
src/file.gcno: cannot open notes file
src/file.gcda: cannot open data file, assuming not executed
No executable lines
# No .gcov files created ❌
```

### After (Working)
```
$ find . -name "*.gcda" | while read gcda_file; do gcov -b "$gcda_file" --object-directory=$(dirname "$gcda_file") 2>/dev/null || true; done
File 'src/auto_discovery_utilities.f90'
Lines executed:81.67% of 60
Creating 'auto_discovery_utilities.f90.gcov'
# Actual .gcov files created ✅
```

## Verification
✅ Tested workflow generates working .gcov files  
✅ Handles missing/invalid files gracefully  
✅ Works with FPM build directory structure  
✅ Compatible with zero-configuration mode  

fixes #431