### PR TITLE
fix: validate all percentage thresholds to range 0.0-100.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,6 +26,7 @@
 - [ ] #482: style: fix line length violation in test_cli_flag_parsing_issue_472.f90
 
 ## DOING (Current Work)
+- [ ] #473: Input validation bug: minimum threshold accepts invalid values (-1, 999999) [EPIC: Infrastructure Stabilization]
 
 ## PRODUCT_BACKLOG (High-level Features)
 - [ ] Advanced Coverage Analytics & Reporting

--- a/src/config_flag_processor.f90
+++ b/src/config_flag_processor.f90
@@ -8,7 +8,7 @@ module config_flag_processor
     use config_parser_utils, only: flag_requires_value, add_source_path, &
                                     add_exclude_pattern, add_include_pattern, &
                                     parse_real_with_error, parse_integer_with_error, &
-                                    parse_diff_files
+                                    parse_diff_files, parse_threshold_with_error
     implicit none
     private
 
@@ -190,11 +190,11 @@ contains
         
         select case (flag)
         case ("--minimum", "-m", "--threshold")
-            call parse_real_with_error(value, config%minimum_coverage, &
-                                       "minimum coverage", success, error_message)
+            call parse_threshold_with_error(value, config%minimum_coverage, &
+                                            "minimum coverage", success, error_message)
         case ("--fail-under")
-            call parse_real_with_error(value, config%fail_under_threshold, &
-                                       "fail threshold", success, error_message)
+            call parse_threshold_with_error(value, config%fail_under_threshold, &
+                                            "fail threshold", success, error_message)
         case ("--threads", "-t")
             call parse_integer_with_error(value, config%threads, &
                                           "thread count", success, error_message)
@@ -209,8 +209,8 @@ contains
                 success = .true.
             end if
         case ("--diff-threshold")
-            call parse_real_with_error(value, config%diff_threshold, &
-                                       "diff threshold", success, error_message)
+            call parse_threshold_with_error(value, config%diff_threshold, &
+                                            "diff threshold", success, error_message)
         case ("--test-timeout")
             call parse_integer_with_error(value, config%test_timeout_seconds, &
                                           "test timeout", success, error_message)

--- a/src/config_parser_utils.f90
+++ b/src/config_parser_utils.f90
@@ -23,6 +23,7 @@ module config_parser_utils
     public :: get_long_form_option
     public :: flag_requires_value
     public :: parse_diff_files
+    public :: parse_threshold_with_error
 
 contains
 
@@ -313,5 +314,34 @@ contains
         config%diff_current_file = current_file
 
     end subroutine parse_diff_files
+
+    subroutine parse_threshold_with_error(str, value, value_name, success, &
+                                          error_message)
+        !! Parse threshold value with range validation (0.0-100.0)
+        character(len=*), intent(in) :: str
+        real, intent(out) :: value
+        character(len=*), intent(in) :: value_name
+        logical, intent(out) :: success
+        character(len=*), intent(out) :: error_message
+
+        ! First parse as regular real number
+        call parse_real_value(str, value, success)
+        
+        if (.not. success) then
+            error_message = "Invalid " // trim(value_name) // ": '" // &
+                           trim(str) // "'"
+            return
+        end if
+
+        ! Validate range (0.0 to 100.0)
+        if (value < 0.0 .or. value > 100.0) then
+            success = .false.
+            error_message = "Invalid " // trim(value_name) // ": '" // &
+                           trim(str) // "' (must be between 0.0 and 100.0)"
+        else
+            error_message = ""
+        end if
+
+    end subroutine parse_threshold_with_error
 
 end module config_parser_utils

--- a/test/test_threshold_validation_issue_473.f90
+++ b/test/test_threshold_validation_issue_473.f90
@@ -1,0 +1,118 @@
+program test_threshold_validation_issue_473
+    !! Comprehensive test for issue #473 - Input validation for all threshold parameters
+    !! 
+    !! Tests that all percentage thresholds validate range (0.0-100.0):
+    !! - --minimum (and aliases -m, --threshold)
+    !! - --fail-under
+    !! - --diff-threshold
+    use config_types, only: config_t
+    use fortcov_config, only: parse_config
+    use test_framework_utilities
+    implicit none
+    
+    type(test_counter_t) :: counter
+    
+    print *, "========================================="
+    print *, "Test: Threshold Validation Issue #473"
+    print *, "========================================="
+    print *, ""
+    
+    call init_test_counter(counter)
+    
+    ! Test --minimum threshold
+    print *, "Testing --minimum threshold:"
+    print *, "---------------------------------"
+    call test_threshold_parameter(counter, "--minimum", "minimum coverage")
+    call test_threshold_parameter(counter, "-m", "minimum coverage (short)")
+    call test_threshold_parameter(counter, "--threshold", &
+                                  "minimum coverage (alias)")
+    
+    ! Test --fail-under threshold
+    print *, ""
+    print *, "Testing --fail-under threshold:"
+    print *, "---------------------------------"
+    call test_threshold_parameter(counter, "--fail-under", "fail threshold")
+    
+    ! Test --diff-threshold
+    print *, ""
+    print *, "Testing --diff-threshold:"
+    print *, "---------------------------------"
+    call test_threshold_parameter(counter, "--diff-threshold", &
+                                  "diff threshold")
+    
+    call print_test_summary(counter, "Threshold Validation Issue #473")
+    
+    if (counter%failed > 0) then
+        call exit(1)
+    else
+        call exit(0)
+    end if
+    
+contains
+    
+    subroutine test_threshold_parameter(counter, flag, description)
+        type(test_counter_t), intent(inout) :: counter
+        character(len=*), intent(in) :: flag, description
+        
+        ! Test valid values
+        call test_single_value(counter, flag, "50.0", .true., &
+                               trim(description) // " - valid mid-range")
+        call test_single_value(counter, flag, "0.0", .true., &
+                               trim(description) // " - lower boundary")
+        call test_single_value(counter, flag, "100.0", .true., &
+                               trim(description) // " - upper boundary")
+        
+        ! Test invalid values (should be rejected)
+        call test_single_value(counter, flag, "-1", .false., &
+                               trim(description) // " - negative")
+        call test_single_value(counter, flag, "101", .false., &
+                               trim(description) // " - above 100")
+        call test_single_value(counter, flag, "999999", .false., &
+                               trim(description) // " - extreme value")
+    end subroutine test_threshold_parameter
+    
+    subroutine test_single_value(counter, flag, value, should_succeed, test_desc)
+        type(test_counter_t), intent(inout) :: counter
+        character(len=*), intent(in) :: flag, value, test_desc
+        logical, intent(in) :: should_succeed
+        type(config_t) :: config
+        character(len=512) :: error_message
+        logical :: success
+        character(len=256), allocatable :: args(:)
+        
+        allocate(args(2))
+        args(1) = flag
+        args(2) = value
+        
+        call parse_config(args, config, success, error_message)
+        
+        if (should_succeed) then
+            if (success) then
+                call increment_pass(counter)
+                print *, "  ✅ PASS: ", trim(test_desc), " (", &
+                        trim(value), ")"
+            else
+                call increment_fail(counter)
+                print *, "  ❌ FAIL: ", trim(test_desc), " (", &
+                        trim(value), ")"
+                print *, "    Expected success but got error: ", &
+                        trim(error_message)
+            end if
+        else
+            if (.not. success) then
+                call increment_pass(counter)
+                print *, "  ✅ PASS: ", trim(test_desc), " (", &
+                        trim(value), ") correctly rejected"
+                print *, "    Error: ", trim(error_message)
+            else
+                call increment_fail(counter)
+                print *, "  ❌ FAIL: ", trim(test_desc), " (", &
+                        trim(value), ")"
+                print *, "    Expected rejection but value was accepted"
+            end if
+        end if
+        
+        deallocate(args)
+    end subroutine test_single_value
+    
+end program test_threshold_validation_issue_473


### PR DESCRIPTION
## Summary
- Implemented input validation for all percentage threshold parameters
- Validates --minimum, --fail-under, and --diff-threshold to ensure values are between 0.0 and 100.0
- Provides clear error messages for out-of-range values

## Changes
1. **Added `parse_threshold_with_error` function** in `config_parser_utils.f90`
   - Validates that percentage values are within 0.0-100.0 range
   - Returns descriptive error messages for invalid values

2. **Updated threshold parameter parsing** in `config_flag_processor.f90`
   - Changed --minimum, --fail-under, and --diff-threshold to use the new validation function
   - Ensures consistent validation across all percentage parameters

3. **Added comprehensive test coverage** in `test_threshold_validation_issue_473.f90`
   - Tests all three threshold parameters with valid and invalid values
   - Verifies boundary conditions (0.0 and 100.0)
   - Tests rejection of negative and extreme values

## Test Results
All 30 tests pass successfully:
- Valid values (0.0, 50.0, 100.0) are accepted
- Invalid values (negative, >100) are correctly rejected with clear error messages
- All threshold flags including aliases work correctly

## Example Error Messages
```
Invalid minimum coverage: '-1' (must be between 0.0 and 100.0)
Invalid fail threshold: '999999' (must be between 0.0 and 100.0)
Invalid diff threshold: '150.5' (must be between 0.0 and 100.0)
```

Fixes #473