### PR TITLE
docs: fix terminal format documentation contradiction with actual CLI support

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,6 +33,7 @@
 - [ ] #482: style: fix line length violation in test_cli_flag_parsing_issue_472.f90
 
 ## DOING (Current Work)
+- [ ] #468: Default format 'terminal' not supported, contradicting help documentation [EPIC: Documentation Defects]
 
 ## PRODUCT_BACKLOG (High-level Features)
 - [ ] Advanced Coverage Analytics & Reporting

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Complete documentation is available in the [`doc/`](doc/) directory:
 
 ## Features
 
-- **Multiple output formats**: terminal (default), markdown, json, html, xml
+- **Multiple output formats**: text, markdown (default), json, html, xml
 - **Build system integration**: Works with FPM, CMake, Make, and custom build systems  
 - **CI/CD ready**: Designed for automated testing pipelines
 - **Security focused**: Path validation, command injection prevention
@@ -86,7 +86,7 @@ fortcov --source=src *.gcov  # Shows terminal coverage output
 fortcov --source=src *.gcov  # Analyze gcov files with terminal output
 ```
 
-**Current Implementation Status**: Terminal coverage analysis is fully functional. File output formats (markdown, json, html, xml) display "would be generated" but do not create actual files yet.
+**Current Implementation Status**: Text coverage analysis is fully functional. File output formats (markdown, json, html, xml) display "would be generated" but do not create actual files yet.
 
 **CI/CD integration:**
 ```bash

--- a/doc/user/configuration.md
+++ b/doc/user/configuration.md
@@ -25,7 +25,7 @@ FortCov uses **Fortran namelist format** (`fortcov.nml`) for configuration:
 |--------|------|---------|-------------|
 | `source_paths` | string array | `'src/'` | Source directories to analyze |
 | `exclude_patterns` | string array | `''` | File patterns to exclude (glob syntax) |
-| `output_format` | string | `'terminal'` | Output format: terminal (default), markdown, json, html, xml |
+| `output_format` | string | `'markdown'` | Output format: text, markdown (default), json, html, xml |
 | `output_path` | string | `'-'` | Output file path ('-' for stdout) |
 | `minimum_coverage` | real | `0.0` | Minimum coverage threshold (0-100) |
 | `verbose` | logical | `.false.` | Enable verbose output |

--- a/doc/user/examples.md
+++ b/doc/user/examples.md
@@ -70,7 +70,7 @@ fortcov --source=src *.gcov  # Shows coverage statistics in terminal
 fortcov --source=src *.gcov --quiet
 ```
 
-**Current Implementation Status**: Terminal coverage analysis is fully functional. File output formats show "would be generated" but do not create actual files yet.
+**Current Implementation Status**: Text coverage analysis is fully functional. File output formats show "would be generated" but do not create actual files yet.
 
 ## Build System Integration
 

--- a/doc/user/usage-guide.md
+++ b/doc/user/usage-guide.md
@@ -40,7 +40,7 @@ fortcov --source . --exclude "test/*" --exclude "*.mod" *.gcov
 fortcov --source=src *.gcov
 
 # File output formats display 'would be generated' but do not create files
-# Available format options: terminal (default), markdown, json, html, xml  
+# Available format options: text, markdown (default), json, html, xml  
 fortcov --source=src *.gcov --format=json   # Shows format but doesn't create file
 fortcov --source=src *.gcov --format=xml    # Shows format but doesn't create file
 

--- a/fortcov.nml.example
+++ b/fortcov.nml.example
@@ -9,7 +9,7 @@
 ! Configuration Options:
 ! - source_paths: Source directories to analyze (string array)
 ! - exclude_patterns: File patterns to exclude using glob syntax (string array)
-! - output_format: 'terminal' (default), 'markdown', 'json', 'html', 'xml'
+! - output_format: 'text', 'markdown' (default), 'json', 'html', 'xml'
 ! - output_path: Output file path, use '-' for stdout (default)
 ! - minimum_coverage: Coverage threshold 0.0-100.0 for warnings
 ! - gcov_executable: Path to gcov executable (default: 'gcov')
@@ -19,7 +19,7 @@
 &fortcov_config
     source_paths = 'src/', 'app/'
     exclude_patterns = '*.mod', '*.o', 'build/*', 'test/*', 'vendor/*'
-    output_format = 'terminal'
+    output_format = 'markdown'
     output_path = '-'
     minimum_coverage = 80.0
     gcov_executable = 'gcov'

--- a/src/config_defaults.f90
+++ b/src/config_defaults.f90
@@ -188,7 +188,7 @@ contains
             config%source_paths(1) = "."
         end if
 
-        ! Terminal format is valid and supported - no conversion needed
+        ! Text format is valid and supported - no conversion needed
 
         ! Set default output path if not set
         if (len_trim(config%output_path) == 0) then

--- a/src/config_help.f90
+++ b/src/config_help.f90
@@ -38,7 +38,7 @@ contains
         print '(A)', "Output Options:"
         print '(A)', "  -o, --output PATH         Output file path"
         print '(A)', "  -f, --format FORMAT       Output format:"
-        print '(A)', "                            terminal (default), markdown, json, html, xml"
+        print '(A)', "                            text, markdown (default), json, html, xml"
         print '(A)', ""
         print '(A)', "Coverage Options:"
         print '(A)', "  -m, --minimum PERCENT     Set minimum coverage percentage"


### PR DESCRIPTION
## Summary
- Fix documentation claiming 'terminal' format is supported when it's not
- Replace 'terminal' with 'text' (actual supported format)
- Update default format from 'terminal' to 'markdown' (matches implementation)
- Eliminate contradiction between help documentation and actual CLI behavior

## Files Changed
- `src/config_help.f90`: CLI help text format list
- `README.md`: Feature description format list
- `fortcov.nml.example`: Configuration example and comments
- `doc/user/configuration.md`: Configuration reference table
- `doc/user/usage-guide.md`: Usage format options
- `doc/user/examples.md`: Implementation status text
- `src/config_defaults.f90`: Code comment correction

## Test Plan
- [x] CLI help shows correct formats: `text, markdown (default), json, html, xml`
- [x] `--format=terminal` fails with "Unsupported output format: terminal"
- [x] `--format=text` works without format validation errors
- [x] Default behavior uses markdown format (no errors)
- [x] All documentation consistently lists same supported formats

## Issue Resolution
Fixes #468 - Default format 'terminal' not supported, contradicting help documentation

Generated with [Claude Code](https://claude.ai/code)