### PR TITLE
docs: fix fortcov.nml.example to remove non-existent lib/ directory reference

### DIFF
--- a/fortcov.nml.example
+++ b/fortcov.nml.example
@@ -41,7 +41,7 @@
 ! Example: Development configuration
 ! Copy and modify for development workflow
 !&fortcov_config
-!    source_paths = 'src/', 'lib/'
+!    source_paths = 'src/', 'app/'
 !    exclude_patterns = '*.mod', 'test/*'
 !    output_format = 'markdown'
 !    output_path = 'dev-coverage.md'


### PR DESCRIPTION
## Summary
- Fixes issue #471 by removing non-existent 'lib/' directory reference from fortcov.nml.example development configuration
- Replaces 'lib/' with 'app/' which actually exists in the project structure
- Ensures configuration validation passes for users copying the example configuration

## Configuration Path Fix
- **Before**: Development config referenced non-existent `'lib/'` directory
- **After**: Development config references existing `'app/'` directory alongside `'src/'`
- **Impact**: Users get working configuration examples out-of-box without path validation failures

## Test plan
- [x] Verify 'app/' directory exists in project structure
- [x] Check all three configuration examples reference existing directories only
- [x] Ensure configuration format remains valid Fortran namelist syntax
- [x] Confirm no other non-existent path references in examples

Generated with [Claude Code](https://claude.ai/code)