### PR TITLE
style: fix line length violations in coverage_file_processor.f90

### DIFF
--- a/src/coverage_file_processor.f90
+++ b/src/coverage_file_processor.f90
@@ -28,8 +28,10 @@ contains
         ! Import at procedure level to avoid circular dependency (Issue #281)
         use coverage_workflows, only: discover_coverage_files
         type(config_t), intent(in) :: config
-        character(len=MAX_FILE_PATH_LENGTH), allocatable, intent(out) :: coverage_files(:)
-        character(len=MAX_FILE_PATH_LENGTH), allocatable, intent(out) :: filtered_files(:)
+        character(len=MAX_FILE_PATH_LENGTH), allocatable, &
+            intent(out) :: coverage_files(:)
+        character(len=MAX_FILE_PATH_LENGTH), allocatable, &
+            intent(out) :: filtered_files(:)
         
         character(len=MAX_FILE_PATH_LENGTH) :: temp_files(MAX_ARRAY_SIZE)
         integer :: num_files, i, filtered_count
@@ -62,13 +64,15 @@ contains
             end do
             
             ! Allocate and copy filtered results
-            allocate(character(len=MAX_FILE_PATH_LENGTH) :: filtered_files(filtered_count))
+            allocate(character(len=MAX_FILE_PATH_LENGTH) :: &
+                filtered_files(filtered_count))
             if (filtered_count > 0) then
                 filtered_files(1:filtered_count) = temp_files(1:filtered_count)
             end if
         else
             ! No filtering needed - copy all files
-            allocate(character(len=MAX_FILE_PATH_LENGTH) :: filtered_files(size(coverage_files)))
+            allocate(character(len=MAX_FILE_PATH_LENGTH) :: &
+                filtered_files(size(coverage_files)))
             filtered_files = coverage_files
         end if
         
@@ -103,7 +107,8 @@ contains
             
             if (.not. file_exists(files(i))) then
                 if (.not. config%quiet) then
-                    write(*,'(A)') "Warning: Coverage file not found: " // trim(files(i))
+                    write(*,'(A)') "Warning: Coverage file not found: " // &
+                        trim(files(i))
                 end if
                 cycle
             end if


### PR DESCRIPTION
## Summary
- Applied Fortran continuation syntax (` &`) to fix line length violations in `coverage_file_processor.f90`
- All lines now comply with QADS style standards (≤88 characters)
- Maximum line length reduced from 97 to 88 characters

## Changes
- Fixed 5 lines that exceeded the 88-character limit:
  - Line 31: Function parameter declaration with intent(out)
  - Line 32: Function parameter declaration with intent(out) 
  - Line 65: allocate statement for filtered_files array
  - Line 71: allocate statement for filtered_files array with size
  - Line 106: Warning message write statement

## Test Plan
- [x] Build verification: `fmp build` passes with no compilation errors
- [x] Line length verification: All lines ≤88 characters confirmed
- [x] Syntax correctness: Fortran continuation syntax properly applied

Fixes #480

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>