### PR TITLE
style: fix line length violation in test file

### DIFF
--- a/test/test_cli_flag_parsing_issue_472.f90
+++ b/test/test_cli_flag_parsing_issue_472.f90
@@ -225,7 +225,8 @@ contains
         else if (.not. allocated(config%source_paths) .or. &
                  size(config%source_paths) < 2) then
             call increment_fail(counter)
-            print *, "  ❌ FAIL: Multiple source directories parsed but array size incorrect"
+            print *, "  ❌ FAIL: Multiple source directories parsed but &
+                     &array size incorrect"
         else if (trim(config%source_paths(1)) /= "src" .or. &
                  trim(config%source_paths(2)) /= "lib") then
             call increment_fail(counter)


### PR DESCRIPTION
Fixes #482

## Summary
- Fixed line 228 in test_cli_flag_parsing_issue_472.f90 exceeding 88 character limit
- Split 92-character print statement with emoji using Fortran continuation syntax
- Line now properly formatted at ≤88 characters per QADS style standards

## Changes
- Line 228: Split long print statement into two lines with proper continuation
- Maintains emoji and message readability
- Ensures QADS compliance for 88-character line limit

## Testing
- Verified tests still compile and run successfully
- Line length now compliant with project standards
- Final SPRINT_BACKLOG item completion enables PLAY workflow