### PR TITLE
style: fix line length violations in validation test files

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,13 +3,13 @@
 ## SPRINT_BACKLOG (Code Quality & Defect Resolution - Sprint 3)
 
 ### EPIC: Technical Debt Reduction (HIGH PRIORITY)
-- [ ] #516: style: fix minor line length violations in validation test files
 
 ### EPIC: Bug Fixes & Stability (CRITICAL PRIORITY)
 
 ### EPIC: Sprint Validation & Quality Assurance (MEDIUM PRIORITY)
 
 ## DOING (Current Work)
+- [ ] #516: style: fix minor line length violations in validation test files [EPIC: Technical Debt Reduction]
 
 ## PRODUCT_BACKLOG (High-level Features)
 - [ ] Advanced Coverage Analytics & Reporting

--- a/test/test_auto_discovery_end_to_end_validation.f90
+++ b/test/test_auto_discovery_end_to_end_validation.f90
@@ -10,8 +10,9 @@ program test_auto_discovery_end_to_end_validation
     use build_system_detector, only: detect_build_system, build_system_info_t
     use coverage_workflows, only: execute_auto_test_workflow
     ! Test environment detection handled internally
-    use zero_config_auto_discovery_integration, only: enhance_zero_config_with_auto_discovery, &
-                                                      execute_zero_config_complete_workflow
+    use zero_config_auto_discovery_integration, only: &
+        enhance_zero_config_with_auto_discovery, &
+        execute_zero_config_complete_workflow
     use fortcov_config, only: config_t, parse_config
     use fortcov, only: run_coverage_analysis
     implicit none
@@ -146,7 +147,8 @@ contains
         
         ! Clean and test Make detection
         call execute_command_line('rm -f ' // trim(workspace_path) // '/CMakeLists.txt')
-        call execute_command_line('echo "all:" > ' // trim(workspace_path) // '/Makefile')
+        call execute_command_line('echo "all:" > ' // &
+                                  trim(workspace_path) // '/Makefile')
         
         block
             use error_handling, only: error_context_t
@@ -245,7 +247,8 @@ contains
             found_gcov_file = temp_dir // '/found_gcov.txt'
             
             call execute_command_line('find ' // trim(workspace_path) // &
-                                     ' -name "*.gcov" > "' // trim(found_gcov_file) // '"')
+                                     ' -name "*.gcov" > "' // &
+                                     trim(found_gcov_file) // '"')
             
             open(newunit=unit_number, file=trim(found_gcov_file), &
                  status='old', iostat=iostat, action='read')
@@ -589,7 +592,8 @@ contains
 
     function test_environment_detected() result(is_test_env)
         !! Use consistent test environment detection
-        use test_environment_utils, only: test_environment_detected_util => test_environment_detected
+        use test_environment_utils, only: &
+            test_environment_detected_util => test_environment_detected
         logical :: is_test_env
         
         is_test_env = test_environment_detected_util()

--- a/test/test_cli_consistency_validation.f90
+++ b/test/test_cli_consistency_validation.f90
@@ -2,7 +2,8 @@ program test_cli_consistency_validation
     !! CLI Consistency Validation Test (Issue #509)
     !!
     !! Validates that all documented CLI examples from README.md work correctly.
-    !! This ensures Sprint 2 success criteria #3: "CLI consistency - all documented examples work"
+    !! This ensures Sprint 2 success criteria #3: "CLI consistency - all
+    !! documented examples work"
     !!
     !! Tests every example from the documentation to ensure they parse correctly
     !! and produce expected configuration results.
@@ -539,8 +540,10 @@ contains
         
         if (success1 .and. success2) then
             call assert_test(config1%verbose .eqv. config2%verbose .and. &
-                           size(config1%source_paths) > 0 .and. size(config2%source_paths) > 0 .and. &
-                           trim(config1%source_paths(1)) == trim(config2%source_paths(1)) .and. &
+                           size(config1%source_paths) > 0 .and. &
+                           size(config2%source_paths) > 0 .and. &
+                           trim(config1%source_paths(1)) == &
+                           trim(config2%source_paths(1)) .and. &
                            trim(config1%output_path) == trim(config2%output_path), &
                            "Flag ordering independence", &
                            "Results should be identical regardless of order")

--- a/test/test_config_validation_433.f90
+++ b/test/test_config_validation_433.f90
@@ -1,5 +1,6 @@
 program test_config_validation_433
-    !! Test for issue #433 - Configuration validation always fails for valid CLI arguments
+    !! Test for issue #433 - Configuration validation always fails for valid CLI
+    !! arguments
     use fortcov_config
     use config_types
     implicit none

--- a/test/test_infrastructure_core_validation.f90
+++ b/test/test_infrastructure_core_validation.f90
@@ -30,9 +30,12 @@ contains
         end if
         
         ! Core infrastructure stability tests
-        call test_command_execution_stability(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_file_io_reliability(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_memory_management_stability(test_count, passed_tests, all_tests_passed)
+        call test_command_execution_stability(temp_dir, test_count, &
+                                              passed_tests, all_tests_passed)
+        call test_file_io_reliability(temp_dir, test_count, passed_tests, &
+                                      all_tests_passed)
+        call test_memory_management_stability(test_count, passed_tests, &
+                                              all_tests_passed)
         call test_error_handling_robustness(test_count, passed_tests, all_tests_passed)
         
         ! Cleanup test environment
@@ -40,7 +43,8 @@ contains
         
     end subroutine run_core_infrastructure_tests
 
-    subroutine assert_test(condition, test_name, details, test_count, passed_tests, all_tests_passed)
+    subroutine assert_test(condition, test_name, details, test_count, &
+                           passed_tests, all_tests_passed)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: test_name, details
         integer, intent(inout) :: test_count
@@ -59,7 +63,8 @@ contains
         end if
     end subroutine assert_test
 
-    subroutine test_command_execution_stability(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_command_execution_stability(temp_dir, test_count, &
+                                                passed_tests, all_tests_passed)
         !! Tests that command execution is stable and reliable
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -91,7 +96,8 @@ contains
         ! Test 3: Multiple rapid commands
         do i = 1, 5
             call execute_command_line('touch "' // trim(temp_dir) // '/rapid_' // &
-                                     char(48 + i) // '.txt"', wait=.true., exitstat=exit_status)
+                                     char(48 + i) // '.txt"', &
+                                     wait=.true., exitstat=exit_status)
             if (exit_status /= 0) exit
         end do
         call assert_test(exit_status == 0, "Rapid command execution", &
@@ -107,7 +113,8 @@ contains
         
     end subroutine test_command_execution_stability
 
-    subroutine test_file_io_reliability(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_file_io_reliability(temp_dir, test_count, &
+                                        passed_tests, all_tests_passed)
         !! Tests file I/O operations for reliability
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -165,7 +172,8 @@ contains
         
     end subroutine test_file_io_reliability
 
-    subroutine test_memory_management_stability(test_count, passed_tests, all_tests_passed)
+    subroutine test_memory_management_stability(test_count, &
+                                                passed_tests, all_tests_passed)
         !! Tests memory management stability
         integer, intent(inout) :: test_count
         integer, intent(inout) :: passed_tests  
@@ -212,7 +220,8 @@ contains
         
     end subroutine test_memory_management_stability
 
-    subroutine test_error_handling_robustness(test_count, passed_tests, all_tests_passed)
+    subroutine test_error_handling_robustness(test_count, passed_tests, &
+                                              all_tests_passed)
         !! Tests error handling mechanisms for robustness
         integer, intent(inout) :: test_count
         integer, intent(inout) :: passed_tests  

--- a/test/test_infrastructure_extended_validation.f90
+++ b/test/test_infrastructure_extended_validation.f90
@@ -14,7 +14,8 @@ module test_infrastructure_extended_validation
     
 contains
 
-    subroutine run_extended_infrastructure_tests(test_count, passed_tests, all_tests_passed)
+    subroutine run_extended_infrastructure_tests(test_count, passed_tests, &
+                                                  all_tests_passed)
         !! Run extended infrastructure validation tests
         integer, intent(inout) :: test_count
         integer, intent(inout) :: passed_tests  
@@ -31,21 +32,30 @@ contains
         end if
         
         ! Extended infrastructure tests
-        call test_test_isolation_guarantees(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_concurrent_execution_safety(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_framework_assertion_reliability(test_count, passed_tests, all_tests_passed)
-        call test_cleanup_mechanisms(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_resource_leak_prevention(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_environment_detection_accuracy(test_count, passed_tests, all_tests_passed)
-        call test_temporary_file_management(temp_dir, test_count, passed_tests, all_tests_passed)
-        call test_system_interaction_stability(temp_dir, test_count, passed_tests, all_tests_passed)
+        call test_test_isolation_guarantees(temp_dir, test_count, &
+                                            passed_tests, all_tests_passed)
+        call test_concurrent_execution_safety(temp_dir, test_count, &
+                                              passed_tests, all_tests_passed)
+        call test_framework_assertion_reliability(test_count, &
+                                                  passed_tests, all_tests_passed)
+        call test_cleanup_mechanisms(temp_dir, test_count, passed_tests, &
+                                     all_tests_passed)
+        call test_resource_leak_prevention(temp_dir, test_count, &
+                                           passed_tests, all_tests_passed)
+        call test_environment_detection_accuracy(test_count, &
+                                                 passed_tests, all_tests_passed)
+        call test_temporary_file_management(temp_dir, test_count, &
+                                            passed_tests, all_tests_passed)
+        call test_system_interaction_stability(temp_dir, test_count, &
+                                               passed_tests, all_tests_passed)
         
         ! Cleanup test environment
         call execute_command_line('rm -rf "' // temp_dir // '"')
         
     end subroutine run_extended_infrastructure_tests
 
-    subroutine assert_test(condition, test_name, details, test_count, passed_tests, all_tests_passed)
+    subroutine assert_test(condition, test_name, details, test_count, &
+                           passed_tests, all_tests_passed)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: test_name, details
         integer, intent(inout) :: test_count
@@ -64,7 +74,8 @@ contains
         end if
     end subroutine assert_test
 
-    subroutine test_test_isolation_guarantees(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_test_isolation_guarantees(temp_dir, test_count, &
+                                              passed_tests, all_tests_passed)
         !! Tests that tests are properly isolated from each other
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -113,7 +124,8 @@ contains
         
     end subroutine test_test_isolation_guarantees
 
-    subroutine test_concurrent_execution_safety(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_concurrent_execution_safety(temp_dir, test_count, &
+                                                passed_tests, all_tests_passed)
         !! Tests safety of concurrent operations
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -140,7 +152,8 @@ contains
         
     end subroutine test_concurrent_execution_safety
 
-    subroutine test_framework_assertion_reliability(test_count, passed_tests, all_tests_passed)
+    subroutine test_framework_assertion_reliability(test_count, &
+                                                    passed_tests, all_tests_passed)
         !! Tests that the test framework assertions work reliably
         integer, intent(inout) :: test_count
         integer, intent(inout) :: passed_tests  
@@ -174,7 +187,8 @@ contains
         
     end subroutine test_framework_assertion_reliability
 
-    subroutine test_cleanup_mechanisms(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_cleanup_mechanisms(temp_dir, test_count, &
+                                       passed_tests, all_tests_passed)
         !! Tests that cleanup mechanisms work properly
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -212,7 +226,8 @@ contains
         
     end subroutine test_cleanup_mechanisms
 
-    subroutine test_resource_leak_prevention(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_resource_leak_prevention(temp_dir, test_count, &
+                                             passed_tests, all_tests_passed)
         !! Tests that resources are properly managed to prevent leaks
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -241,7 +256,8 @@ contains
         
     end subroutine test_resource_leak_prevention
 
-    subroutine test_environment_detection_accuracy(test_count, passed_tests, all_tests_passed)
+    subroutine test_environment_detection_accuracy(test_count, &
+                                                   passed_tests, all_tests_passed)
         !! Tests accuracy of environment detection
         integer, intent(inout) :: test_count
         integer, intent(inout) :: passed_tests  
@@ -260,7 +276,8 @@ contains
         
     end subroutine test_environment_detection_accuracy
 
-    subroutine test_temporary_file_management(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_temporary_file_management(temp_dir, test_count, &
+                                              passed_tests, all_tests_passed)
         !! Tests temporary file management capabilities
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count
@@ -305,13 +322,15 @@ contains
 
     function test_environment_detected() result(is_test_env)
         !! Use consistent test environment detection  
-        use test_environment_utils, only: test_environment_detected_util => test_environment_detected
+        use test_environment_utils, only: &
+            test_environment_detected_util => test_environment_detected
         logical :: is_test_env
         
         is_test_env = test_environment_detected_util()
     end function test_environment_detected
 
-    subroutine test_system_interaction_stability(temp_dir, test_count, passed_tests, all_tests_passed)
+    subroutine test_system_interaction_stability(temp_dir, test_count, &
+                                                 passed_tests, all_tests_passed)
         !! Tests stability of system interactions
         character(len=*), intent(in) :: temp_dir
         integer, intent(inout) :: test_count

--- a/test/test_infrastructure_stability_validation.f90
+++ b/test/test_infrastructure_stability_validation.f90
@@ -1,11 +1,13 @@
 program test_infrastructure_stability_validation
     !! Test Infrastructure Stability Validation (Issue #509)
     !!
-    !! Validates Sprint 2 success criteria #4: "Test infrastructure stable (all tests pass)"
+    !! Validates Sprint 2 success criteria #4: "Test infrastructure stable
+    !! (all tests pass)"
     !! This test checks that the testing infrastructure is reliable and can be used
     !! to validate all other functionality without introducing instability.
     !!
-    !! This main program coordinates modular infrastructure tests to meet size requirements.
+    !! This main program coordinates modular infrastructure tests to meet
+    !! size requirements.
     
     use iso_fortran_env, only: output_unit
     use test_infrastructure_core_validation, only: run_core_infrastructure_tests

--- a/test/test_security_validation_only.f90
+++ b/test/test_security_validation_only.f90
@@ -63,12 +63,12 @@ program test_security_validation_only
     print *, "======================================================================"
     if (total_failures == 0) then
         print *, "✅ ALL SECURITY VALIDATION TESTS PASSED"
-        print *, "======================================================================"
+        print *, "==============================================================="
         call exit(0)
     else
         write(error_unit, '(A,I0,A)') "❌ ", total_failures, &
             " SECURITY TEST SUITES FAILED"
-        print *, "======================================================================"
+        print *, "==============================================================="
         call exit(1)
     end if
     

--- a/test/test_sprint_2_validation_comprehensive.f90
+++ b/test/test_sprint_2_validation_comprehensive.f90
@@ -13,7 +13,8 @@ program test_sprint_2_validation_comprehensive
     use iso_fortran_env, only: output_unit, error_unit
     use fortcov_config, only: parse_config, config_t
     use fortcov, only: run_coverage_analysis
-    use zero_config_auto_discovery_integration, only: execute_zero_config_complete_workflow
+    use zero_config_auto_discovery_integration, only: &
+        execute_zero_config_complete_workflow
     use build_system_detector, only: detect_build_system, build_system_info_t
     ! Test environment detection handled internally
     implicit none
@@ -160,7 +161,8 @@ contains
             temp_dir = get_temp_dir()
             gcov_files_list = temp_dir // '/gcov_files.txt'
             
-            call execute_command_line('find . -name "*.gcov" > "' // trim(gcov_files_list) // '" 2>/dev/null')
+            call execute_command_line('find . -name "*.gcov" > "' // &
+                                      trim(gcov_files_list) // '" 2>/dev/null')
             
             open(newunit=unit_number, file=trim(gcov_files_list), status='old', &
                  iostat=iostat, action='read')
@@ -192,7 +194,8 @@ contains
                         "Should not always show 0.00%")
         
         ! Cleanup
-            call execute_command_line('rm -f "' // trim(gcov_files_list) // '" mock_coverage_test.f90.gcov')
+            call execute_command_line('rm -f "' // trim(gcov_files_list) // &
+                                      '" mock_coverage_test.f90.gcov')
         end block
         
     end subroutine test_criterion_2_coverage_parsing_accuracy
@@ -271,13 +274,15 @@ contains
         write(output_unit, '(A)') "=== CRITERION 4: Test Infrastructure Stability ==="
         
         ! Test 4.1: Fork bomb prevention mechanism
-        call execute_command_line('touch .fortcov_execution_marker', wait=.true., exitstat=exit_status)
+        call execute_command_line('touch .fortcov_execution_marker', &
+                                  wait=.true., exitstat=exit_status)
         inquire(file='.fortcov_execution_marker', exist=marker_exists)
         call assert_test(marker_exists, "Fork bomb marker creation", &
                         "Should be able to create marker file")
         
         ! Test 4.2: Marker cleanup functionality
-        call execute_command_line('rm -f .fortcov_execution_marker', wait=.true., exitstat=exit_status)
+        call execute_command_line('rm -f .fortcov_execution_marker', &
+                                  wait=.true., exitstat=exit_status)
         inquire(file='.fortcov_execution_marker', exist=marker_exists)
         call assert_test(.not. marker_exists, "Fork bomb marker cleanup", &
                         "Should be able to remove marker file")
@@ -328,7 +333,8 @@ contains
                         "Should detect created marker")
         
         ! Test 5.3: Automatic cleanup on startup (simulate main.f90 behavior)
-        call execute_command_line('rm -f .fortcov_execution_marker', wait=.true., exitstat=exit_status)
+        call execute_command_line('rm -f .fortcov_execution_marker', &
+                                  wait=.true., exitstat=exit_status)
         call assert_test(exit_status == 0, "Automatic marker cleanup", &
                         "Should clean up stale markers")
         
@@ -385,7 +391,8 @@ contains
         call assert_test(success, "Mixed arguments parsing", &
                         "Should handle multiple args")
         if (success) then
-            call assert_test(config%verbose .and. index(config%output_path, "test.md") > 0, &
+            call assert_test(config%verbose .and. &
+                            index(config%output_path, "test.md") > 0, &
                             "Multiple flags preserved", "All flags should be set")
         end if
         
@@ -512,7 +519,8 @@ contains
 
     function test_environment_detected() result(is_test_env)
         !! Use consistent test environment detection
-        use test_environment_utils, only: test_environment_detected_util => test_environment_detected
+        use test_environment_utils, only: &
+            test_environment_detected_util => test_environment_detected
         logical :: is_test_env
         
         is_test_env = test_environment_detected_util()


### PR DESCRIPTION
Fixes #516

Fixes line length violations (89-101 chars) in validation test function signatures to comply with 88 character limit.

**Changes:**
- Fixed long function signatures with proper Fortran line continuation ()
- Fixed long use statements and variable declarations
- Fixed long command line calls and assert statements
- Ensured all validation test files comply with 88 char limit
- All functionality preserved, only formatting changes

**Files affected:**
- test/test_auto_discovery_end_to_end_validation.f90
- test/test_cli_consistency_validation.f90  
- test/test_config_validation_433.f90
- test/test_infrastructure_core_validation.f90
- test/test_infrastructure_extended_validation.f90
- test/test_security_validation_only.f90
- test/test_sprint_2_validation_comprehensive.f90
- test/test_infrastructure_stability_validation.f90