### PR TITLE
fix: auto-discovery fails to find existing gcov files

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,10 +7,9 @@
 ### EPIC: Source Organization (CRITICAL - 118 FILES!)
 
 ### EPIC: Core Functionality Recovery
-- [ ] #596: fix: auto-discovery fails to find existing gcov files
 
 ## DOING (Current Work)
-- [ ] #595: fix: file output formats do not generate actual files [EPIC: Core Functionality Recovery]
+- [ ] #596: fix: auto-discovery fails to find existing gcov files [EPIC: Core Functionality Recovery]
 
 ## PRODUCT_BACKLOG (High-level Features)
 - [ ] Advanced Coverage Analytics & Reporting

--- a/src/coverage/coverage_workflows_impl.f90
+++ b/src/coverage/coverage_workflows_impl.f90
@@ -277,8 +277,8 @@ contains
         if (allocated(config%coverage_files)) then
             ! Use explicitly specified coverage files
             files = config%coverage_files
-        else if (config%zero_configuration_mode) then
-            ! Use zero-configuration auto-discovery
+        else if (config%zero_configuration_mode .or. config%auto_discovery) then
+            ! Use zero-configuration or auto-discovery mode
             files = auto_discover_coverage_files_priority()
         else
             ! Delegate to gcov processor for discovery


### PR DESCRIPTION
## Summary
- Fixes the --auto-discovery flag failing to find existing .gcov files (#596)
- The issue was in the coverage file discovery logic that only checked for zero_configuration_mode
- Now properly checks for both zero_configuration_mode OR auto_discovery flag

## Test plan
- [x] Tested with real gcov files in examples/build_systems/fpm/basic_example/
- [x] Verified --auto-discovery finds 3 gcov files correctly  
- [x] Verified default behavior (auto-discovery enabled) works
- [x] Verified --no-auto-discovery properly disables discovery
- [x] Ran targeted test suite to ensure no regressions

## Technical Details
Changed `determine_coverage_files_source()` in coverage_workflows_impl.f90:
```fortran
# Before (broken)
else if (config%zero_configuration_mode) then

# After (fixed) 
else if (config%zero_configuration_mode .or. config%auto_discovery) then
```

This enables auto-discovery to find .gcov files in priority order:
1. build/gcov/*.gcov (standard location)
2. current directory *.gcov 
3. build directory recursively

Fixes #596

🤖 Generated with [Claude Code](https://claude.ai/code)