### PR TITLE
fix: resolve coverage output file generation for all formats

### DIFF
--- a/src/config/config_defaults_core.f90
+++ b/src/config/config_defaults_core.f90
@@ -13,7 +13,7 @@ module config_defaults_core
     private
 
     public :: initialize_default_config
-    public :: apply_html_default_filename
+    public :: apply_default_output_filename
     public :: apply_default_output_path_for_coverage_files
     public :: ensure_zero_config_output_directory
     public :: get_max_files_from_env
@@ -63,16 +63,30 @@ contains
 
     end subroutine initialize_default_config
 
-    subroutine apply_html_default_filename(config)
-        !! Apply default filename when HTML output is selected without path
+    subroutine apply_default_output_filename(config)
+        !! Apply default filename when output format is selected without path
         type(config_t), intent(inout) :: config
 
-        if (config%output_format == "html" .and. &
-            len_trim(config%output_path) == 0) then
-            config%output_path = "coverage.html"
+        ! Apply default output paths for all formats when not specified
+        if (len_trim(config%output_path) == 0) then
+            select case (trim(config%output_format))
+            case ("html")
+                config%output_path = "coverage.html"
+            case ("json")
+                config%output_path = "coverage.json"
+            case ("xml")
+                config%output_path = "coverage.xml"
+            case ("markdown", "md")
+                config%output_path = "coverage.md"
+            case ("text")
+                config%output_path = "coverage.txt"
+            case default
+                ! For unknown formats, use generic extension
+                config%output_path = "coverage." // trim(config%output_format)
+            end select
         end if
 
-    end subroutine apply_html_default_filename
+    end subroutine apply_default_output_filename
 
     subroutine apply_default_output_path_for_coverage_files(config)
         !! Apply default output path when processing coverage files directly
@@ -83,10 +97,23 @@ contains
         has_coverage_files = allocated(config%coverage_files) .and. &
                               size(config%coverage_files) > 0
 
-        if (has_coverage_files .and. &
-            config%output_format == "html" .and. &
-            len_trim(config%output_path) == 0) then
-            config%output_path = "coverage.html"
+        ! Apply default output paths for all formats when not specified
+        if (len_trim(config%output_path) == 0) then
+            select case (trim(config%output_format))
+            case ("html")
+                config%output_path = "coverage.html"
+            case ("json")
+                config%output_path = "coverage.json"
+            case ("xml")
+                config%output_path = "coverage.xml"
+            case ("markdown", "md")
+                config%output_path = "coverage.md"
+            case ("text")
+                config%output_path = "coverage.txt"
+            case default
+                ! For unknown formats, use generic extension
+                config%output_path = "coverage." // trim(config%output_format)
+            end select
         end if
 
     end subroutine apply_default_output_path_for_coverage_files

--- a/src/config/config_parser_command.f90
+++ b/src/config/config_parser_command.f90
@@ -199,7 +199,7 @@ contains
         call prevent_fork_bomb_with_manual_files(config)
 
         ! Apply final defaults
-        call apply_html_default_filename(config)
+        call apply_default_output_filename(config)
         call ensure_zero_config_output_directory(config)
 
     end subroutine handle_zero_configuration_with_overrides
@@ -245,8 +245,8 @@ contains
         ! Apply fork bomb prevention (Issue #395)
         call prevent_fork_bomb_with_manual_files(config)
 
-        ! Apply defaults for HTML output
-        call apply_html_default_filename(config)
+        ! Apply defaults for output formats
+        call apply_default_output_filename(config)
         call apply_default_output_path_for_coverage_files(config)
 
     end subroutine handle_normal_configuration


### PR DESCRIPTION
## Summary
- Fix critical core value proposition failure where fortcov appeared to execute successfully but generated no output files
- Resolve empty output path issue causing "Cannot write to output file ''" error for non-HTML formats
- Ensure all supported formats (HTML, JSON, XML, Markdown, Text) generate output files by default

## Root Cause Analysis
The issue was in the configuration defaults system:
- `config_defaults_core.f90` only provided default output paths for HTML format
- Other formats (markdown, json, xml, text) would default to empty string for `output_path`  
- When no `--output` flag was provided, the empty path caused silent failures in report generation
- Users experienced successful command execution with no tangible output files

## Implementation Details
- Enhanced `apply_default_output_filename()` to handle all supported output formats
- Updated `apply_default_output_path_for_coverage_files()` for consistency across formats
- Added format-specific default filenames:
  - HTML: `coverage.html`
  - JSON: `coverage.json`
  - XML: `coverage.xml` 
  - Markdown/MD: `coverage.md`
  - Text: `coverage.txt`
  - Unknown formats: `coverage.<format>`

## Testing Performed
- ✅ All formats generate files without `--output` flag specified
- ✅ Custom output paths via `--output` flag continue to work correctly
- ✅ Full test suite passes with 0 failures
- ✅ Comprehensive format testing confirms proper file generation:
  ```bash
  fortcov --source=. *.gcov                    # → coverage.md
  fortcov --source=. *.gcov --format=json      # → coverage.json
  fortcov --source=. *.gcov --format=xml       # → coverage.xml
  fortcov --source=. *.gcov --format=html      # → coverage.html
  ```

## Test Plan
- [x] Verify default output generation for all formats
- [x] Verify custom output paths still work with `--output` flag
- [x] Run full test suite to ensure no regressions
- [x] Test format-specific file extensions are correct

## Impact
Restores core product functionality - users can now access coverage reports in all supported formats without specifying output paths.

Fixes #622

🤖 Generated with [Claude Code](https://claude.ai/code)