### PR TITLE
test: verify issue #614 fix with comprehensive test coverage

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,7 +3,6 @@
 ## SPRINT_BACKLOG (Sprint 8: Architectural Recovery & Core Functionality Restoration)
 
 ### EPIC: Critical Functionality Recovery 
-- [ ] #614: Fix markdown report generation with empty output file path
 - [ ] #613: Fix test suite failures (directory removal and missing executable errors)
 
 ### EPIC: Architectural Debt Resolution  
@@ -31,7 +30,7 @@
 - [ ] #623: Final Sprint 8 findings integration and documentation consolidation
 
 ## DOING (Current Work)
-- [ ] #618: Fix format inconsistencies and missing output file handling (branch: fix-618) [EPIC: Critical Functionality Recovery]
+- [ ] #614: Fix markdown report generation with empty output file path (branch: fix-614) [EPIC: Critical Functionality Recovery]
 
 ## PRODUCT_BACKLOG (High-level Features)
 - [ ] Advanced Coverage Analytics & Reporting

--- a/test/test_issue_614_verification.f90
+++ b/test/test_issue_614_verification.f90
@@ -1,0 +1,82 @@
+program test_issue_614_verification
+    !! Comprehensive test for Issue #614: Empty output file path fix
+    !! Verifies that default output paths are correctly applied for all formats
+    
+    use config_core, only: config_t, parse_config
+    use config_types, only: MAX_ARRAY_SIZE
+    implicit none
+    
+    logical :: all_tests_passed
+    
+    print '(A)', "=== Issue #614 Verification Test ==="
+    print '(A)', "Testing default output path generation for all formats"
+    print '(A)', ""
+    
+    all_tests_passed = .true.
+    
+    ! Test 1: Markdown format (default)
+    call test_format("markdown", "coverage.md", all_tests_passed)
+    
+    ! Test 2: JSON format
+    call test_format("json", "coverage.json", all_tests_passed)
+    
+    ! Test 3: XML format  
+    call test_format("xml", "coverage.xml", all_tests_passed)
+    
+    ! Test 4: HTML format
+    call test_format("html", "coverage.html", all_tests_passed)
+    
+    ! Test 5: Text format
+    call test_format("text", "coverage.txt", all_tests_passed)
+    
+    print '(A)', ""
+    if (all_tests_passed) then
+        print '(A)', "✅ ALL TESTS PASSED - Issue #614 is FIXED"
+        print '(A)', "   Default output paths are correctly applied for all formats"
+    else
+        print '(A)', "❌ SOME TESTS FAILED - Issue #614 still exists"
+        stop 1
+    end if
+    
+contains
+
+    subroutine test_format(format_name, expected_output, test_status)
+        character(len=*), intent(in) :: format_name
+        character(len=*), intent(in) :: expected_output
+        logical, intent(inout) :: test_status
+        
+        character(len=256) :: test_args(3)
+        type(config_t) :: config
+        logical :: parse_success
+        character(len=512) :: error_msg
+        
+        ! Build test arguments dynamically
+        test_args(1) = "--source=src"
+        test_args(2) = "--format=" // trim(format_name)
+        test_args(3) = "test.gcov"
+        
+        ! Parse configuration with no --output flag
+        call parse_config(test_args, config, parse_success, error_msg)
+        
+        if (.not. parse_success) then
+            print '(A,A,A)', "❌ FAIL: ", format_name, " - Parse failed: " // trim(error_msg)
+            test_status = .false.
+            return
+        end if
+        
+        ! Check if output path was set to expected default
+        if (len_trim(config%output_path) == 0) then
+            print '(A,A,A)', "❌ FAIL: ", format_name, " - Output path is empty"
+            test_status = .false.
+        else if (trim(config%output_path) == trim(expected_output)) then
+            print '(A,A,A,A,A)', "✅ PASS: ", format_name, " -> ", trim(config%output_path), &
+                                   " (correct default)"
+        else
+            print '(A,A,A,A,A,A,A)', "❌ FAIL: ", format_name, " -> ", trim(config%output_path), &
+                                      " (expected: ", trim(expected_output), ")"
+            test_status = .false.
+        end if
+        
+    end subroutine test_format
+
+end program test_issue_614_verification


### PR DESCRIPTION
## Summary
- Add comprehensive test verification for issue #614 fix
- Demonstrates that PR #624 successfully resolved the empty output file path issue  
- Verifies default output paths work correctly for all supported formats

## Issue #614 Status: ALREADY FIXED ✅

### Root Cause
The original issue occurred when `apply_default_output_filename()` was not being called in certain configuration paths, causing "Cannot write to output file ''" errors.

### Fix Verification
PR #624 (commit 569abc1) already fixed this by ensuring `apply_default_output_filename()` is called in both:
- Zero-configuration mode (line 202 in config_parser_command.f90)
- Normal configuration mode (line 249 in config_parser_command.f90)

### Test Results
All format-specific defaults work correctly:
```
✅ PASS: markdown -> coverage.md (correct default)
✅ PASS: json -> coverage.json (correct default)  
✅ PASS: xml -> coverage.xml (correct default)
✅ PASS: html -> coverage.html (correct default)
✅ PASS: text -> coverage.txt (correct default)
```

### Evidence
- Development version: `fortcov --source=src *.gcov` works correctly ✅
- System version (0.4.0): Same command fails with empty path error ❌
- The fix exists in current codebase and functions as intended

## Test Plan
- [x] Comprehensive format testing for default output paths
- [x] Verify fix works in development version
- [x] Confirm issue exists in older system version
- [x] All tests pass demonstrating issue #614 is resolved

This PR documents that issue #614 was already resolved and adds test coverage to prevent regression.

🤖 Generated with [Claude Code](https://claude.ai/code)