### PR TITLE
docs: Remove outdated exit code note from README - fixes #788

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,15 @@ fortcov --source=src *.gcov --output=coverage.md  # Creates detailed markdown re
 
 **CI/CD integration:**
 ```bash
-# Note: Exit code fix pending in PR #741
+# Coverage analysis with threshold checking - returns proper exit codes
 fortcov --source=src *.gcov --fail-under 80 --output=coverage.md
-echo "Exit code: $?"  # Will be 2 for threshold failures after fix
+echo "Exit code: $?"  # Returns 0=success, 2=threshold not met, 3=no coverage data
+
+# Example CI/CD usage
+if ! fortcov --source=src *.gcov --fail-under 80 --quiet; then
+    echo "Coverage below 80% threshold - build failed"
+    exit 1
+fi
 ```
 
 ## Known Issues


### PR DESCRIPTION
## Summary
- Remove obsolete reference to PR #741 in CI/CD integration section
- Update documentation to reflect current working exit code functionality
- Add practical CI/CD integration examples with proper error handling

## Technical Verification
Exit codes are fully implemented and tested:
- **CI Validation**: All tests pass including `test_threshold_validation_issue_473` and `test_zero_config_complete_workflow`
- **Working Examples**: CLI integration tests verify README examples are copy-paste ready
- **Implementation Status**: Exit codes 0 (success), 2 (threshold not met), 3 (no coverage data) working correctly

## Documentation Updates
- Replace outdated "pending in PR #741" note with accurate functionality description
- Add practical CI/CD usage pattern with conditional error handling
- Maintain example-first approach with copy-paste ready code snippets

🤖 Generated with [Claude Code](https://claude.ai/code)