### PR TITLE
fix: resolve gcov command construction failure (fixes #868, #867)

### DIFF
--- a/src/gcov/gcov_processor_auto.f90
+++ b/src/gcov/gcov_processor_auto.f90
@@ -421,9 +421,17 @@ contains
         integer :: i, gcov_command_result
         character(len=1024) :: gcov_command
         character(len=256) :: gcno_file, gcda_base
+        character(len=256) :: gcov_executable
         logical :: gcno_exists
         
         call clear_error_context(error_ctx)
+        
+        ! Ensure gcov executable is set
+        if (allocated(config%gcov_executable) .and. len_trim(config%gcov_executable) > 0) then
+            gcov_executable = trim(config%gcov_executable)
+        else
+            gcov_executable = 'gcov'  ! Default to 'gcov' if not specified
+        end if
         
         ! Process each .gcda file
         do i = 1, size(gcda_files)
@@ -445,7 +453,7 @@ contains
             end if
             
             ! Run gcov on the .gcda file with full path
-            write(gcov_command, '(A,1X,A)') trim(config%gcov_executable), &
+            write(gcov_command, '(A,1X,A)') trim(gcov_executable), &
                 trim(gcda_files(i))
             call execute_command_line(trim(gcov_command), &
                 exitstat=gcov_command_result)

--- a/test/test_gcov_auto_processing.f90
+++ b/test/test_gcov_auto_processing.f90
@@ -221,6 +221,7 @@ contains
         !! Initialize test configuration with sensible defaults
         type(config_t), intent(out) :: config
         
+        config%gcov_executable = 'gcov'  ! Set the gcov executable
         config%auto_discovery = .true.
         config%auto_test_execution = .false.
         config%verbose = .false.


### PR DESCRIPTION
## Summary
- Fixed EXECUTE_COMMAND_LINE command construction failure at line 451
- Resolved invalid gcov command execution causing test failures
- Ensures gcov_executable is properly initialized with default value

## Changes
1. **src/gcov/gcov_processor_auto.f90**: Added validation to ensure gcov_executable is properly set, defaulting to 'gcov' if not configured
2. **test/test_gcov_auto_processing.f90**: Updated test configuration to explicitly set gcov_executable

## Root Cause
The issue occurred when `config%gcov_executable` was empty or unallocated, causing the command construction at line 448-449 to write an invalid command string. When `execute_command_line` was called with this malformed command, it resulted in "Invalid command line" runtime error.

## Test Plan
- [x] Run `fpm test --target test_gcov_auto_processing_runner` - passes
- [x] Run `fpm test --target minimal_gcov_test` - no command construction errors
- [x] Verify gcov command is properly constructed with default 'gcov' when not configured
- [x] Verify gcov command uses configured executable when provided

🤖 Generated with [Claude Code](https://claude.ai/code)