### PR TITLE
fix: EPIC 2 CLI functionality restoration - JSON output and exit codes (#865, #869)

### DIFF
--- a/doc/developer/exit-codes.md
+++ b/doc/developer/exit-codes.md
@@ -1,0 +1,137 @@
+# Exit Code Classification System
+
+## Overview
+
+The FortCov exit code system provides standardized Unix-compatible exit codes for CI/CD integration and automated tooling. This replaces the previous STOP statement approach with proper exit() calls.
+
+## Exit Code Categories
+
+### Success (0)
+- **EXIT_SUCCESS (0)**: Operation completed successfully
+  - All tests passed
+  - Coverage analysis completed
+  - Configuration validation succeeded
+  - No errors encountered
+
+### General Failures (1-9)
+
+#### EXIT_FAILURE (1)
+General failure - catch-all for unspecified errors
+- Unexpected runtime errors
+- Unclassified failures
+- Generic operation failures
+
+#### EXIT_THRESHOLD_NOT_MET (2)
+Coverage threshold requirement not satisfied
+- Coverage percentage below configured threshold
+- Quality gate failure
+- CI/CD pipeline blocker
+
+#### EXIT_NO_COVERAGE_DATA (3)
+No coverage data available for analysis
+- Missing .gcov files
+- Empty coverage results
+- No source files processed
+
+#### EXIT_INVALID_CONFIG (4)
+Configuration error or invalid parameters
+- Invalid command-line arguments
+- Malformed configuration file
+- Conflicting options
+
+#### EXIT_FILE_ACCESS_ERROR (5)
+File system access issues
+- Source files not found
+- Permission denied
+- I/O operation failures
+
+#### EXIT_MEMORY_ERROR (6)
+Memory allocation or management errors
+- Out of memory conditions
+- Allocation failures
+- Memory corruption detected
+
+#### EXIT_VALIDATION_ERROR (7)
+Validation check failures
+- Security validation errors
+- Input validation failures
+- Constraint violations
+
+## Usage Examples
+
+### Command Line
+```bash
+# Success case
+fortcov --source=src --output=coverage.md
+echo $?  # Returns 0
+
+# Threshold not met
+fortcov --source=src --threshold=90
+echo $?  # Returns 2 if coverage < 90%
+
+# Invalid configuration
+fortcov --invalid-flag
+echo $?  # Returns 4
+```
+
+### CI/CD Integration
+```yaml
+# GitHub Actions example
+- name: Run coverage analysis
+  run: |
+    fortcov --source=src --threshold=80
+    EXIT_CODE=$?
+    case $EXIT_CODE in
+      0) echo "Coverage passed" ;;
+      2) echo "Coverage below threshold" && exit 1 ;;
+      3) echo "No coverage data found" && exit 1 ;;
+      *) echo "Coverage analysis failed" && exit 1 ;;
+    esac
+```
+
+### Fortran Implementation
+```fortran
+use system_exit_handler, only: exit_success, exit_failure, exit_threshold_not_met
+
+! Success case
+if (coverage >= threshold) then
+    call exit_success("Coverage threshold met")
+end if
+
+! Failure case
+if (coverage < threshold) then
+    call exit_threshold_not_met("Coverage below required threshold")
+end if
+```
+
+## Migration from STOP Statements
+
+All STOP statements have been replaced with appropriate exit() calls:
+
+| Old Code | New Code |
+|----------|----------|
+| `stop 0` | `call exit_success()` |
+| `stop 1` | `call exit_failure()` or specific exit code |
+| `stop 2` | `call exit_threshold_not_met()` |
+
+## Exit Code Handler Module
+
+The `system_exit_handler` module provides:
+- Unified exit handling interface
+- Consistent error messaging
+- Proper Unix exit codes
+- CI/CD compatibility
+
+## Best Practices
+
+1. **Use specific exit codes** when the error type is known
+2. **Provide error messages** for debugging
+3. **Document exit codes** in help text
+4. **Test exit codes** in CI/CD pipelines
+5. **Maintain backward compatibility** where possible
+
+## Related Documentation
+
+- [Error Handling](./error-handling.md)
+- [CI/CD Integration](./ci-integration.md)
+- [Testing Guide](./testing.md)

--- a/src/core/architecture/size_report_generator.f90
+++ b/src/core/architecture/size_report_generator.f90
@@ -202,7 +202,8 @@ contains
                      '  "has_violations": ' // logical_to_json(report%has_violations) // ',' // new_line('') // &
                      '  "has_warnings": ' // logical_to_json(report%has_warnings) // ',' // new_line('') // &
                      '  "total_files_scanned": ' // int_to_string(report%total_files_scanned) // ',' // new_line('') // &
-                     '  "total_directories_scanned": ' // int_to_string(report%total_directories_scanned) // ',' // new_line('') // &
+                     '  "total_directories_scanned": ' // &
+                     int_to_string(report%total_directories_scanned) // ',' // new_line('') // &
                      '  "ci_exit_recommendation": "' // report%ci_exit_recommendation // '"'
         
         ! Add file violations array

--- a/src/core/architecture/size_report_generator.f90
+++ b/src/core/architecture/size_report_generator.f90
@@ -67,6 +67,8 @@ contains
         
         if (trim(output_format) == "ci") then
             call generate_ci_report(report, report_text)
+        else if (trim(output_format) == "json") then
+            call generate_json_report(report, report_text)
         else if (trim(output_format) == "human") then
             call generate_human_report(report, report_text)
         else
@@ -184,6 +186,145 @@ contains
         end if
         
     end subroutine append_detailed_violations
+    
+    subroutine generate_json_report(report, report_text)
+        !! Generates JSON format report for machine consumption
+        type(architectural_size_report_t), intent(in) :: report
+        character(len=:), allocatable, intent(out) :: report_text
+        
+        character(len=:), allocatable :: violations_json
+        integer :: i
+        logical :: first_violation
+        
+        ! Start JSON object
+        report_text = '{' // new_line('') // &
+                     '  "summary": "' // escape_json_string(report%summary_message) // '",' // new_line('') // &
+                     '  "has_violations": ' // logical_to_json(report%has_violations) // ',' // new_line('') // &
+                     '  "has_warnings": ' // logical_to_json(report%has_warnings) // ',' // new_line('') // &
+                     '  "total_files_scanned": ' // int_to_string(report%total_files_scanned) // ',' // new_line('') // &
+                     '  "total_directories_scanned": ' // int_to_string(report%total_directories_scanned) // ',' // new_line('') // &
+                     '  "ci_exit_recommendation": "' // report%ci_exit_recommendation // '"'
+        
+        ! Add file violations array
+        if (allocated(report%file_violations) .and. size(report%file_violations) > 0) then
+            report_text = report_text // ',' // new_line('') // '  "file_violations": ['
+            first_violation = .true.
+            do i = 1, size(report%file_violations)
+                if (trim(report%file_violations(i)%severity_level) /= "") then
+                    if (.not. first_violation) then
+                        report_text = report_text // ','
+                    end if
+                    report_text = report_text // new_line('') // '    {' // new_line('') // &
+                        '      "filename": "' // escape_json_string(report%file_violations(i)%filename) // '",' // new_line('') // &
+                        '      "current_lines": ' // int_to_string(report%file_violations(i)%current_lines) // ',' // new_line('') // &
+                        '      "target_limit": ' // int_to_string(report%file_violations(i)%target_limit) // ',' // new_line('') // &
+                        '      "severity_level": "' // trim(report%file_violations(i)%severity_level) // '",' // new_line('') // &
+                        '      "remediation_hint": "' // escape_json_string(report%file_violations(i)%remediation_hint) // '"' // new_line('') // &
+                        '    }'
+                    first_violation = .false.
+                end if
+            end do
+            report_text = report_text // new_line('') // '  ]'
+        else
+            report_text = report_text // ',' // new_line('') // '  "file_violations": []'
+        end if
+        
+        ! Add directory violations array
+        if (allocated(report%directory_violations) .and. size(report%directory_violations) > 0) then
+            report_text = report_text // ',' // new_line('') // '  "directory_violations": ['
+            first_violation = .true.
+            do i = 1, size(report%directory_violations)
+                if (trim(report%directory_violations(i)%severity_level) /= "") then
+                    if (.not. first_violation) then
+                        report_text = report_text // ','
+                    end if
+                    report_text = report_text // new_line('') // '    {' // new_line('') // &
+                        '      "directory": "' // escape_json_string(report%directory_violations(i)%directory_path) // '",' // new_line('') // &
+                        '      "current_items": ' // int_to_string(report%directory_violations(i)%current_items) // ',' // new_line('') // &
+                        '      "soft_limit": ' // int_to_string(report%directory_violations(i)%soft_limit) // ',' // new_line('') // &
+                        '      "hard_limit": ' // int_to_string(report%directory_violations(i)%hard_limit) // ',' // new_line('') // &
+                        '      "severity_level": "' // trim(report%directory_violations(i)%severity_level) // '",' // new_line('') // &
+                        '      "remediation_hint": "' // escape_json_string(report%directory_violations(i)%remediation_hint) // '"' // new_line('') // &
+                        '    }'
+                    first_violation = .false.
+                end if
+            end do
+            report_text = report_text // new_line('') // '  ]'
+        else
+            report_text = report_text // ',' // new_line('') // '  "directory_violations": []'
+        end if
+        
+        ! Close JSON object
+        report_text = report_text // new_line('') // '}' // new_line('')
+        
+    end subroutine generate_json_report
+    
+    function escape_json_string(input_str) result(escaped)
+        !! Escapes special characters in JSON strings
+        character(len=*), intent(in) :: input_str
+        character(len=:), allocatable :: escaped
+        
+        integer :: i, j
+        character(len=1) :: ch
+        character(len=:), allocatable :: temp
+        
+        ! Allocate maximum possible size (each char could become 6 chars \uXXXX)
+        allocate(character(len=len(input_str)*6) :: temp)
+        
+        j = 0
+        do i = 1, len_trim(input_str)
+            ch = input_str(i:i)
+            select case (ch)
+            case ('"')
+                j = j + 1
+                temp(j:j+1) = '\"'
+                j = j + 1
+            case ('\\')
+                j = j + 1  
+                temp(j:j+1) = '\\\\'
+                j = j + 1
+            case (achar(8))  ! Backspace
+                j = j + 1
+                temp(j:j+1) = '\\b'
+                j = j + 1
+            case (achar(12))  ! Form feed
+                j = j + 1
+                temp(j:j+1) = '\\f'
+                j = j + 1
+            case (achar(10))  ! Newline
+                j = j + 1
+                temp(j:j+1) = '\\n'
+                j = j + 1
+            case (achar(13))  ! Carriage return
+                j = j + 1
+                temp(j:j+1) = '\\r'
+                j = j + 1
+            case (achar(9))  ! Tab
+                j = j + 1
+                temp(j:j+1) = '\\t'
+                j = j + 1
+            case default
+                j = j + 1
+                temp(j:j) = ch
+            end select
+        end do
+        
+        escaped = temp(1:j)
+        
+    end function escape_json_string
+    
+    function logical_to_json(val) result(json_str)
+        !! Converts logical value to JSON boolean string
+        logical, intent(in) :: val
+        character(len=:), allocatable :: json_str
+        
+        if (val) then
+            json_str = "true"
+        else
+            json_str = "false"
+        end if
+        
+    end function logical_to_json
     
     function count_file_violations_by_severity(violations, severity) result(count)
         !! Counts file violations matching specific severity level

--- a/src/core/architecture/size_report_generator.f90
+++ b/src/core/architecture/size_report_generator.f90
@@ -216,11 +216,17 @@ contains
                         report_text = report_text // ','
                     end if
                     report_text = report_text // new_line('') // '    {' // new_line('') // &
-                        '      "filename": "' // escape_json_string(report%file_violations(i)%filename) // '",' // new_line('') // &
-                        '      "current_lines": ' // int_to_string(report%file_violations(i)%current_lines) // ',' // new_line('') // &
-                        '      "target_limit": ' // int_to_string(report%file_violations(i)%target_limit) // ',' // new_line('') // &
-                        '      "severity_level": "' // trim(report%file_violations(i)%severity_level) // '",' // new_line('') // &
-                        '      "remediation_hint": "' // escape_json_string(report%file_violations(i)%remediation_hint) // '"' // new_line('') // &
+                        '      "filename": "' // &
+                        escape_json_string(report%file_violations(i)%filename) // '",' // new_line('') // &
+                        '      "current_lines": ' // &
+                        int_to_string(report%file_violations(i)%current_lines) // ',' // new_line('') // &
+                        '      "target_limit": ' // &
+                        int_to_string(report%file_violations(i)%target_limit) // ',' // new_line('') // &
+                        '      "severity_level": "' // &
+                        trim(report%file_violations(i)%severity_level) // '",' // new_line('') // &
+                        '      "remediation_hint": "' // &
+                        escape_json_string(report%file_violations(i)%remediation_hint) // '"' // &
+                        new_line('') // &
                         '    }'
                     first_violation = .false.
                 end if
@@ -240,12 +246,24 @@ contains
                         report_text = report_text // ','
                     end if
                     report_text = report_text // new_line('') // '    {' // new_line('') // &
-                        '      "directory": "' // escape_json_string(report%directory_violations(i)%directory_path) // '",' // new_line('') // &
-                        '      "current_items": ' // int_to_string(report%directory_violations(i)%current_items) // ',' // new_line('') // &
-                        '      "soft_limit": ' // int_to_string(report%directory_violations(i)%soft_limit) // ',' // new_line('') // &
-                        '      "hard_limit": ' // int_to_string(report%directory_violations(i)%hard_limit) // ',' // new_line('') // &
-                        '      "severity_level": "' // trim(report%directory_violations(i)%severity_level) // '",' // new_line('') // &
-                        '      "remediation_hint": "' // escape_json_string(report%directory_violations(i)%remediation_hint) // '"' // new_line('') // &
+                        '      "directory": "' // &
+                        escape_json_string(report%directory_violations(i)%directory_path) // &
+                        '",' // new_line('') // &
+                        '      "current_items": ' // &
+                        int_to_string(report%directory_violations(i)%current_items) // &
+                        ',' // new_line('') // &
+                        '      "soft_limit": ' // &
+                        int_to_string(report%directory_violations(i)%soft_limit) // &
+                        ',' // new_line('') // &
+                        '      "hard_limit": ' // &
+                        int_to_string(report%directory_violations(i)%hard_limit) // &
+                        ',' // new_line('') // &
+                        '      "severity_level": "' // &
+                        trim(report%directory_violations(i)%severity_level) // &
+                        '",' // new_line('') // &
+                        '      "remediation_hint": "' // &
+                        escape_json_string(report%directory_violations(i)%remediation_hint) // &
+                        '"' // new_line('') // &
                         '    }'
                     first_violation = .false.
                 end if

--- a/src/core/system_exit_handler.f90
+++ b/src/core/system_exit_handler.f90
@@ -1,0 +1,138 @@
+module system_exit_handler
+    !! System Exit Handler Module
+    !! 
+    !! Provides unified exit handling with proper Unix exit codes.
+    !! Replaces STOP statements with proper exit() calls for CI/CD integration.
+    !! Addresses Issue #865 - Exit code regression.
+    use constants_core, only: EXIT_SUCCESS, EXIT_FAILURE, EXIT_THRESHOLD_NOT_MET, &
+                              EXIT_NO_COVERAGE_DATA, EXIT_INVALID_CONFIG, &
+                              EXIT_FILE_ACCESS_ERROR, EXIT_MEMORY_ERROR, &
+                              EXIT_VALIDATION_ERROR
+    implicit none
+    private
+    
+    ! Public interface for exit handling
+    public :: exit_with_code
+    public :: exit_success_clean
+    public :: exit_failure_clean
+    public :: exit_invalid_config_clean
+    public :: exit_no_coverage_data_clean
+    public :: exit_threshold_not_met_clean
+    public :: exit_file_access_error_clean
+    public :: exit_memory_error_clean
+    public :: exit_validation_error_clean
+    
+contains
+    
+    subroutine exit_with_code(exit_code, message)
+        !! Exits program with specified exit code and optional message
+        integer, intent(in) :: exit_code
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            if (exit_code /= EXIT_SUCCESS) then
+                write(*, '(A)') trim(message)
+            end if
+        end if
+        
+        call exit(exit_code)
+        
+    end subroutine exit_with_code
+    
+    subroutine exit_success_clean(message)
+        !! Exits with success code (0)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_SUCCESS, message)
+        else
+            call exit_with_code(EXIT_SUCCESS)
+        end if
+        
+    end subroutine exit_success_clean
+    
+    subroutine exit_failure_clean(message)
+        !! Exits with general failure code (1)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_FAILURE, message)
+        else
+            call exit_with_code(EXIT_FAILURE)
+        end if
+        
+    end subroutine exit_failure_clean
+    
+    subroutine exit_invalid_config_clean(message)
+        !! Exits with invalid configuration code (4)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_INVALID_CONFIG, message)
+        else
+            call exit_with_code(EXIT_INVALID_CONFIG)
+        end if
+        
+    end subroutine exit_invalid_config_clean
+    
+    subroutine exit_no_coverage_data_clean(message)
+        !! Exits with no coverage data code (3)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_NO_COVERAGE_DATA, message)
+        else
+            call exit_with_code(EXIT_NO_COVERAGE_DATA)
+        end if
+        
+    end subroutine exit_no_coverage_data_clean
+    
+    subroutine exit_threshold_not_met_clean(message)
+        !! Exits with threshold not met code (2)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_THRESHOLD_NOT_MET, message)
+        else
+            call exit_with_code(EXIT_THRESHOLD_NOT_MET)
+        end if
+        
+    end subroutine exit_threshold_not_met_clean
+    
+    subroutine exit_file_access_error_clean(message)
+        !! Exits with file access error code (5)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_FILE_ACCESS_ERROR, message)
+        else
+            call exit_with_code(EXIT_FILE_ACCESS_ERROR)
+        end if
+        
+    end subroutine exit_file_access_error_clean
+    
+    subroutine exit_memory_error_clean(message)
+        !! Exits with memory error code (6)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_MEMORY_ERROR, message)
+        else
+            call exit_with_code(EXIT_MEMORY_ERROR)
+        end if
+        
+    end subroutine exit_memory_error_clean
+    
+    subroutine exit_validation_error_clean(message)
+        !! Exits with validation error code (7)
+        character(len=*), intent(in), optional :: message
+        
+        if (present(message)) then
+            call exit_with_code(EXIT_VALIDATION_ERROR, message)
+        else
+            call exit_with_code(EXIT_VALIDATION_ERROR)
+        end if
+        
+    end subroutine exit_validation_error_clean
+    
+end module system_exit_handler


### PR DESCRIPTION
## Summary
- Fixed architecture validation JSON output not working with `--architecture-format=json` flag
- Replaced all STOP statements with proper Unix exit codes for CI/CD compatibility
- Implemented comprehensive exit code classification system (0-7)

## Test Plan
- [x] Build project: `fpm build` completes successfully
- [x] JSON output works: `fortcov --validate-architecture --architecture-format=json` produces valid JSON
- [x] Exit codes correct: Various error conditions return appropriate Unix exit codes
- [x] Help text works: `fortcov --help` exits with code 0
- [x] Invalid config detected: `fortcov --invalid-flag` exits with code 4

## Changes
### JSON Output Fix (#869)
- Added `generate_json_report` subroutine in `size_report_generator.f90`
- Implemented JSON escaping for special characters
- Fixed output routing in `main.f90` to properly display JSON when format is selected

### Exit Code System (#865)
- Created `system_exit_handler` module with unified exit handling
- Replaced all `stop` statements with `call exit_*_clean()` functions
- Documented exit code classification in `doc/developer/exit-codes.md`

### Exit Code Reference
```
0 = SUCCESS        - Operation completed successfully
1 = FAILURE        - General failure/unspecified error  
2 = THRESHOLD_NOT_MET - Coverage below threshold
3 = NO_COVERAGE_DATA  - Missing coverage data
4 = INVALID_CONFIG    - Configuration/parameter errors
5 = FILE_ACCESS_ERROR - I/O issues
6 = MEMORY_ERROR      - Allocation failures
7 = VALIDATION_ERROR  - Validation failures
```

## Verification
```bash
# Test JSON output
./build/gfortran_*/app/fortcov --validate-architecture --architecture-format=json

# Test exit codes
./build/gfortran_*/app/fortcov --help; echo $?  # Should return 0
./build/gfortran_*/app/fortcov --invalid-flag; echo $?  # Should return 4
```

Fixes #865
Fixes #869

🤖 Generated with [Claude Code](https://claude.ai/code)