### PR TITLE
style: wrap lines to 88 cols in zero_config_core (fixes #1065)

### DIFF
--- a/src/zero_config/zero_config_core.f90
+++ b/src/zero_config/zero_config_core.f90
@@ -37,7 +37,8 @@ contains
         error_message = ""
         
         ! Apply zero configuration defaults if not already set
-        if (.not. allocated(config%output_path) .or. len_trim(config%output_path) == 0) then
+        if (.not. allocated(config%output_path) .or. &
+            len_trim(config%output_path) == 0) then
             block
                 character(len=:), allocatable :: default_output_path
                 character(len=:), allocatable :: default_output_format
@@ -50,10 +51,18 @@ contains
                                                       default_exclude_patterns)
                 
                 ! Apply defaults to config
-                if (.not. allocated(config%output_path)) config%output_path = default_output_path
-                if (.not. allocated(config%output_format)) config%output_format = default_output_format
-                if (.not. allocated(config%input_format)) config%input_format = default_input_format
-                if (.not. allocated(config%exclude_patterns)) config%exclude_patterns = default_exclude_patterns
+                if (.not. allocated(config%output_path)) then
+                    config%output_path = default_output_path
+                end if
+                if (.not. allocated(config%output_format)) then
+                    config%output_format = default_output_format
+                end if
+                if (.not. allocated(config%input_format)) then
+                    config%input_format = default_input_format
+                end if
+                if (.not. allocated(config%exclude_patterns)) then
+                    config%exclude_patterns = default_exclude_patterns
+                end if
             end block
         end if
         
@@ -97,8 +106,10 @@ contains
             return
         end if
         
-        ! Build system detected - configuration can use the build_info for test commands
-        ! Note: config_t doesn't have build_command field, build_info provides test commands
+        ! Build system detected - configuration can use the build_info
+        ! for test commands
+        ! Note: config_t doesn't have build_command field,
+        ! build_info provides test commands
         
         success = .true.
     end subroutine integrate_build_system_detection
@@ -146,7 +157,8 @@ contains
         if (marker_exists) then
             if (.not. config%quiet) then
                 print '(A)', "🛡️  Fork bomb prevention: zero-config execution disabled"
-                print '(A)', "    (fortcov detected it's running within a test environment)"
+                print '(A)', "    (fortcov detected it's running within a test"
+                print '(A)', "     environment)"
             end if
             exit_code = EXIT_SUCCESS
             return
@@ -171,7 +183,9 @@ contains
             exit_code = execute_auto_test_workflow(config)
             if (exit_code /= 0) then
                 if (.not. config%quiet) then
-                    print '(A)', "FortCov: Auto-test execution failed, proceeding with existing coverage files..."
+                    print '(A)', &
+                        "FortCov: Auto-test execution failed, proceeding " // &
+                        "with existing coverage files..."
                 end if
                 ! Continue with existing coverage files instead of failing
                 exit_code = EXIT_SUCCESS  
@@ -207,14 +221,17 @@ contains
         
         if (.not. config%quiet) then
             if (exit_code == EXIT_SUCCESS) then
-                print '(A)', "FortCov: Zero-configuration coverage analysis completed successfully!"
+                print '(A)', &
+                    "FortCov: Zero-configuration coverage analysis completed " // &
+                    "successfully!"
             else
                 print '(A)', "FortCov: Zero-configuration coverage analysis failed."
             end if
         end if
     end subroutine execute_zero_config_complete_workflow
 
-    subroutine populate_zero_config_with_discovered_files(config, success, error_message)
+    subroutine populate_zero_config_with_discovered_files(config, success, &
+                                                         error_message)
         !! Auto-discover and populate configuration with coverage files and source paths
         type(config_t), intent(inout) :: config
         logical, intent(out) :: success
@@ -235,13 +252,15 @@ contains
         
         if (.not. config%quiet) then
             if (allocated(discovered_coverage_files)) then
-                print '(A,I0)', "FortCov: Discovery returned ", size(discovered_coverage_files), " files"
+                print '(A,I0)', "FortCov: Discovery returned ", &
+                                  size(discovered_coverage_files), " files"
             else
                 print '(A)', "FortCov: Discovery returned no allocated array"
             end if
         end if
         
-        if (.not. allocated(discovered_coverage_files) .or. size(discovered_coverage_files) == 0) then
+        if (.not. allocated(discovered_coverage_files) .or. &
+            size(discovered_coverage_files) == 0) then
             error_message = "No coverage files found in standard locations"
             return
         end if
@@ -257,8 +276,10 @@ contains
         config%source_paths = discovered_source_paths
         
         if (.not. config%quiet) then
-            print '(A,I0,A)', "FortCov: Found ", size(discovered_coverage_files), " coverage files"
-            print '(A,I0,A)', "FortCov: Using ", size(discovered_source_paths), " source paths"
+            print '(A,I0,A)', "FortCov: Found ", &
+                              size(discovered_coverage_files), " coverage files"
+            print '(A,I0,A)', "FortCov: Using ", &
+                              size(discovered_source_paths), " source paths"
         end if
         
         success = .true.


### PR DESCRIPTION
### **User description**
PROBLEM: Lines >88 chars in src/zero_config/zero_config_core.f90 violated project standard.\nEVIDENCE: awk length scan flagged 12 lines >88.\nSOLUTION: Wrap long lines using Fortran free-form continuations and small if-blocks; split long strings and comments.\nVERIFICATION: ./run_ci_tests.sh passed (82/82 run, 0 failed, 7 skipped known).


___

### **PR Type**
Other


___

### **Description**
- Wrap long lines to comply with 88-character limit

- Split conditional statements using line continuations

- Break long print statements and string concatenations

- Convert single-line if statements to multi-line blocks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long lines >88 chars"] --> B["Line continuation &"]
  A --> C["Multi-line if blocks"]
  A --> D["Split string concatenations"]
  B --> E["Compliant 88-char lines"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zero_config_core.f90</strong><dd><code>Format code to 88-character line limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/zero_config/zero_config_core.f90

<ul><li>Wrap long conditional statements using <code>&</code> continuation<br> <li> Convert single-line if statements to multi-line blocks<br> <li> Split long print statements and string concatenations<br> <li> Break long subroutine signatures across multiple lines</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1072/files#diff-fbed5aec5025bc884ac16b2cf063b10326d6816d7b3b2c49d8919ffca4fd69b4">+37/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

