### PR TITLE
refactor(reporting): remove unnecessary _core imports (part of #1036)

### DIFF
--- a/src/coverage/reporters/coverage_stats_reporter.f90
+++ b/src/coverage/reporters/coverage_stats_reporter.f90
@@ -9,7 +9,7 @@ module coverage_stats_reporter
     use config_core
     use coverage_stats_core, only: coverage_stats_t, extended_coverage_stats_t
     use coverage_reporter
-    use report_engine_core
+    use report_engine
     use error_handling_core
     use string_utils, only: int_to_string
     
@@ -64,7 +64,7 @@ contains
         !! Generate coverage reports in specified formats
         use coverage_reporter, only: coverage_reporter_t
         use coverage_reporter_factory, only: create_reporter
-        use report_engine_core, only: report_engine_t
+        use report_engine, only: report_engine_t
         type(coverage_data_t), intent(in) :: coverage_data
         type(line_coverage_stats_t), intent(in) :: stats
         type(config_t), intent(in) :: config

--- a/src/gcov/gcov_executor.f90
+++ b/src/gcov/gcov_executor.f90
@@ -14,7 +14,7 @@ module gcov_executor
     use file_ops_secure, only: safe_mkdir, safe_remove_file, safe_move_file
     use shell_utilities, only: escape_shell_argument
     use secure_command_execution, only: secure_execute_command
-    use xml_utils_core, only: get_base_name
+    use xml_utils, only: get_base_name
     use string_utils, only: int_to_string
     use gcov_executor_helpers, only: sanitize_file_path, is_safe_gcov_command
     implicit none


### PR DESCRIPTION
### **User description**
Problem: Widespread '_core' suffix usage reduces clarity. This PR begins the systematic cleanup per #1036 by switching to existing non-core modules where available.

Changes:
- Use xml_utils instead of xml_utils_core in gcov_executor
- Use report_engine instead of report_engine_core in coverage_stats_reporter

Verification:
- Ran ./run_ci_tests.sh
  Passed: 84, Failed: 0, Skipped: 6 (curated known-failing)

Scope: Phase 1, minimal-risk substitutions only. No public APIs changed.

After merge, we can continue with additional module renames in follow-ups to keep changes small and safe.

Fixes part of #1036


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `_core` imports with non-core modules

- Use `xml_utils` instead of `xml_utils_core`

- Use `report_engine` instead of `report_engine_core`

- Part of systematic module naming cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_core modules"] -- "replace with" --> B["non-core modules"]
  C["xml_utils_core"] -- "becomes" --> D["xml_utils"]
  E["report_engine_core"] -- "becomes" --> F["report_engine"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage_stats_reporter.f90</strong><dd><code>Replace report_engine_core imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coverage/reporters/coverage_stats_reporter.f90

<ul><li>Replace <code>report_engine_core</code> with <code>report_engine</code> in module imports<br> <li> Update both top-level and local use statements</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1082/files#diff-97d24468e6446ea2f92e7e6dd27c52508ee71fb56577c6c72e341ae73c76174a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gcov_executor.f90</strong><dd><code>Replace xml_utils_core import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/gcov/gcov_executor.f90

<ul><li>Replace <code>xml_utils_core</code> with <code>xml_utils</code> in module import<br> <li> Maintain same functionality with cleaner naming</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1082/files#diff-9d572da68807b187fce06fc3dad63a5c033a7273fff58dcb710af544c4d25fdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

