### PR TITLE
refactor(coverage): use xml_utils for XML parsing (part of #1036)

### DIFF
--- a/src/core/coverage/coverage_format_converter.f90
+++ b/src/core/coverage/coverage_format_converter.f90
@@ -14,7 +14,7 @@ module coverage_format_converter
     use coverage_model_core
     use json_io, only: export_json_coverage, import_json_coverage
     use string_utils, only: real_to_string, int_to_string
-    use json_module, only: json_file, json_value, json_core
+    use json_module, only: json_value, json_core
     use json_kinds, only: RK, IK
     use xml_utils, only: is_well_formed_xml, parse_cobertura_xml
     use timestamp_utils, only: get_current_timestamp

--- a/src/gcov/gcov_executor.f90
+++ b/src/gcov/gcov_executor.f90
@@ -419,7 +419,7 @@ contains
         call safe_write_context(error_ctx, "gcov command execution")
     end subroutine handle_gcov_command_failure
 
-    ! get_base_name now imported from xml_utils_core
+    ! get_base_name now imported from xml_utils
 
     ! integer_to_string now imported from iostat_utilities
     


### PR DESCRIPTION
### **User description**
Problem: Issue #1036 requires moving away from meaningless *_core module imports when non-core replacements exist.

Solution:
- Replace direct xml_parser_core import in coverage_format_converter with xml_utils re-export (parse_cobertura_xml).
- Avoided creating cycles (kept xml_attribute_parser dependency on xml_parser_core).

Verification:
- Built with fpm: Project compiled successfully.
- Ran curated CI-safe test suite: 84 passed, 0 failed, 6 skipped (known), CI Hygiene CLEAN.

Commands run:
- fpm build
- ./run_ci_tests.sh

This continues the systematic naming cleanup by preferring non-core modules where available, without broad renames.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `*_core` module imports with non-core equivalents

- Use `xml_utils` instead of `xml_parser_core` for XML parsing

- Use `report_engine` instead of `report_engine_core` for reporting

- Systematic cleanup to improve module naming consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["*_core modules"] -- "replace with" --> B["non-core modules"]
  C["xml_parser_core"] -- "replaced by" --> D["xml_utils"]
  E["report_engine_core"] -- "replaced by" --> F["report_engine"]
  G["xml_utils_core"] -- "replaced by" --> H["xml_utils"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage_format_converter.f90</strong><dd><code>Use xml_utils for XML parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/coverage/coverage_format_converter.f90

<ul><li>Replace <code>xml_parser_core</code> import with <code>xml_utils</code> re-export<br> <li> Use <code>parse_cobertura_xml</code> from <code>xml_utils</code> instead of direct core import<br> <li> Consolidate XML utilities under single import statement</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1084/files#diff-57f0ad336ba12873467fc62ab5a24550b38e40d49f454dbc5c3d7dd48998b899">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coverage_stats_reporter.f90</strong><dd><code>Use report_engine instead of core module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coverage/reporters/coverage_stats_reporter.f90

<ul><li>Replace <code>report_engine_core</code> imports with <code>report_engine</code><br> <li> Update both module-level and procedure-level imports<br> <li> Add missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1084/files#diff-97d24468e6446ea2f92e7e6dd27c52508ee71fb56577c6c72e341ae73c76174a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gcov_executor.f90</strong><dd><code>Use xml_utils instead of core module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/gcov/gcov_executor.f90

<ul><li>Replace <code>xml_utils_core</code> import with <code>xml_utils</code><br> <li> Use <code>get_base_name</code> from non-core XML utilities module</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1084/files#diff-9d572da68807b187fce06fc3dad63a5c033a7273fff58dcb710af544c4d25fdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>xml_attribute_parser.f90</strong><dd><code>Add missing newline at EOF</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reporters/xml_attribute_parser.f90

<ul><li>Add missing newline at end of file<br> <li> Minor formatting improvement for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1084/files#diff-eb8061c397b4fae647c79c7b7d42ac54cf731cadd46eca7de8e67b11d57a869e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

