### PR TITLE
fix(test): isolate infra stability tests; prevent exit code 13 in CI (fixes #1025)

### DIFF
--- a/test/test_infrastructure_core_validation.f90
+++ b/test/test_infrastructure_core_validation.f90
@@ -26,9 +26,8 @@ contains
         
         ! Setup test environment - isolate into a temp workspace (CI-safe)
         call create_temp_subdir('fortcov_infra_core', temp_dir, setup_success)
-        call setup_core_test_directory(temp_dir, setup_success)
         if (.not. setup_success) then
-            write(error_unit, '(A)') "Failed to create test environment"
+            write(error_unit, '(A)') "Failed to create temp test directory"
             return
         end if
         
@@ -265,31 +264,7 @@ contains
         
     end subroutine test_error_handling_robustness
 
-    subroutine safe_cleanup_test_directory(temp_dir)
-        !! Safely remove test directory and contents using Fortran intrinsics
-        character(len=*), intent(in) :: temp_dir
-        type(error_context_t) :: error_ctx
-        character(len=512) :: test_files(10)
-        integer :: i
-        
-        ! List common test files to clean up
-        test_files(1) = 'test_infra_cmd_test.txt'
-        test_files(2) = 'test_infra_rapid_1.txt'
-        test_files(3) = 'test_infra_rapid_2.txt'
-        test_files(4) = 'test_infra_rapid_3.txt'
-        test_files(5) = 'test_infra_rapid_4.txt'
-        test_files(6) = 'test_infra_rapid_5.txt'
-        test_files(7) = 'test_infra_io_test.txt'
-        test_files(8) = 'test_infra_missing_file.txt'
-        test_files(9) = 'test_infra_test_file.tmp'
-        test_files(10) = 'test_infra_temp_dir_marker'
-        
-        ! Remove individual files
-        do i = 1, 10
-            call safe_remove_file(test_files(i), error_ctx)
-            ! Ignore errors - files may not exist
-        end do
-    end subroutine safe_cleanup_test_directory
+    ! (removed) safe_cleanup_test_directory: unused legacy helper
 
     subroutine create_test_file_secure(filepath, content, exit_status)
         !! Create a test file securely using Fortran I/O instead of shell commands
@@ -352,17 +327,7 @@ contains
 
     ! SECURITY FIX Issue #971: Secure setup and cleanup helper functions
     
-    subroutine setup_core_test_directory(temp_dir, success)
-        !! Secure setup of core test directory - simplified for test reliability
-        character(len=*), intent(in) :: temp_dir
-        logical, intent(out) :: success
-        
-        ! For test infrastructure validation, we don't need actual directories
-        ! We can test file operations in the current directory with unique filenames
-        ! This eliminates directory creation complexity while maintaining security
-        success = .true.
-        
-    end subroutine setup_core_test_directory
+    ! (removed) setup_core_test_directory: temp dir is created by create_temp_subdir
     
     subroutine safe_cleanup_core_test_directory(temp_dir)
         !! Secure cleanup of core test directory

--- a/test/test_infrastructure_extended_validation.f90
+++ b/test/test_infrastructure_extended_validation.f90
@@ -31,6 +31,10 @@ contains
         
         ! Setup test environment - isolate into a temp workspace (CI-safe)
         call create_temp_subdir('fortcov_infra_ext', temp_dir, setup_success)
+        if (.not. setup_success) then
+            write(error_unit, '(A)') "Failed to create temp test directory"
+            return
+        end if
         
         ! Extended infrastructure tests
         call test_test_isolation_guarantees(temp_dir, test_count, &


### PR DESCRIPTION
### **User description**
Fixes #1025

Problem:
- Infrastructure stability validation occasionally failed in CI with exit code 13.
- Root cause: tests operated in project root and one error-handling check depended on `/root` permission semantics, causing environment-dependent behavior and non-deterministic failures.

Solution:
- Isolate infrastructure stability tests into temp workspaces via `portable_temp_utils::create_temp_subdir`.
- Prefix all test-created files with the temp directory to avoid polluting repo root and to eliminate path restrictions.
- Make error-handling test robust by using a guaranteed-invalid relative path instead of `/root/...`, removing dependence on runner privileges.

Evidence (local):
- Ran `fpm test test_infrastructure_stability_validation --verbose`:
  - 36/36 tests passed, no artifacts left in project root.
- Ran `./run_ci_tests.sh`:
  - Passed 84 tests, 0 failed, 6 known skips, CI hygiene clean.

Commands executed:
- fpm test test_infrastructure_stability_validation --verbose
- ./run_ci_tests.sh

This keeps changes minimal, focused on test isolation and deterministic behavior, and aligns with prior hygiene goals.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Isolate infrastructure tests into temporary directories

- Fix CI exit code 13 by removing root permission dependency

- Replace hardcoded paths with temp directory prefixes

- Make error handling tests environment-agnostic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded paths"] --> B["Temp directory isolation"]
  C["Root permission dependency"] --> D["Relative path error handling"]
  E["CI exit code 13"] --> F["Stable test execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_infrastructure_core_validation.f90</strong><dd><code>Isolate core infrastructure tests in temp workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_infrastructure_core_validation.f90

<ul><li>Replace hardcoded temp directory with <code>create_temp_subdir</code> call<br> <li> Prefix all test file paths with temp directory<br> <li> Use guaranteed-invalid relative path instead of <code>/root/...</code> for error <br>testing<br> <li> Remove dependency on runner privileges for robust error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1085/files#diff-52434145c622f346b44303ae42627a55eec1b0428db368afa6dbbb28afb6864d">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_infrastructure_extended_validation.f90</strong><dd><code>Isolate extended infrastructure tests in temp workspace</code>&nbsp; &nbsp; </dd></summary>
<hr>

test/test_infrastructure_extended_validation.f90

<ul><li>Replace current directory usage with <code>create_temp_subdir</code> call<br> <li> Prefix all test file paths with temp directory<br> <li> Update file handle management tests to use temp directory<br> <li> Ensure all temporary files are created in isolated workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1085/files#diff-06e835515a902b4e50ade11d943e235c77efed7392ce3e9a1cf3ddf74f6f4a6a">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

