### PR TITLE
fix(tui): robust TUI manager cleanup and configurable timeout (fixes #995)

### DIFF
--- a/src/core/reporting/report_engine_terminal.f90
+++ b/src/core/reporting/report_engine_terminal.f90
@@ -3,6 +3,7 @@ module report_engine_terminal
     !! 
     !! Handles terminal UI and browser functionality.
     !! Extracted from report_engine.f90 for SRP compliance (Issue #718).
+    use iso_fortran_env, only: real64
     use coverage_model_core
     use data_transformer_core
     use data_transformer_types
@@ -63,7 +64,8 @@ contains
         end if
         
         ! In interactive mode, start the full TUI with proper loop control
-        call start_interactive_tui(session, terminal_output, success, error_msg)
+        call start_interactive_tui(session, terminal_output, success, error_msg, &
+                                   real(config%startup_timeout_seconds, real64))
     end subroutine launch_terminal_browser_session
     
     ! Generate styled terminal output

--- a/src/core/reporting/report_generator_core.f90
+++ b/src/core/reporting/report_generator_core.f90
@@ -3,6 +3,7 @@ module report_generator_core
     !! 
     !! Extracted from report_engine.f90 for SRP compliance (Issue #718).
     !! Responsible for generating HTML and terminal reports.
+    use iso_fortran_env, only: real64
     use coverage_model_core
     use data_transformer_core
     use data_transformer_types
@@ -127,8 +128,9 @@ contains
             return
         end if
         
-        ! Start interactive TUI
-        call start_interactive_tui(session, terminal_output, success, error_msg)
+        ! Start interactive TUI with configurable timeout
+        call start_interactive_tui(session, terminal_output, success, error_msg, &
+                                   real(config%startup_timeout_seconds, real64))
     end subroutine generator_generate_terminal
     
     ! Generate diff report between two coverage datasets

--- a/src/core/tui/tui_manager_core.f90
+++ b/src/core/tui/tui_manager_core.f90
@@ -35,17 +35,30 @@ contains
     end subroutine generate_terminal_display
 
     ! Start interactive TUI with proper main loop
-    subroutine start_interactive_tui(session, display_content, success, error_msg)
+    subroutine start_interactive_tui(session, display_content, success, error_msg, &
+                                     max_runtime_seconds)
         type(terminal_session_t), intent(inout) :: session
         character(len=*), intent(in) :: display_content
         logical, intent(out) :: success
         character(len=:), allocatable, intent(out) :: error_msg
+        real(real64), intent(in), optional :: max_runtime_seconds
 
         type(tui_engine_t) :: tui
         type(tui_config_t) :: tui_config
+        logical :: tui_initialized
+        integer :: ios
+        logical :: terminal_ok
 
         success = .false.
         error_msg = ""
+        tui_initialized = .false.
+        terminal_ok = .true.
+
+        ! Verify session state before proceeding
+        if (.not. session%is_active) then
+            error_msg = "TUI session is not active; aborting startup"
+            return
+        end if
 
         ! Configure TUI engine
         call tui_config%init()
@@ -56,29 +69,48 @@ contains
 
         ! Initialize TUI engine
         call tui%init(tui_config)
+        tui_initialized = .true.
 
         ! Set display content
         tui%display_buffer = display_content
 
         ! Display initial content
         if (session%colors_enabled) then
-            print *, char(27)//'[2J'//char(27)//'[H'  ! Clear screen and home cursor
+            write(*,'(A)',iostat=ios) char(27)//'[2J'//char(27)//'[H'
+            if (ios /= 0) then
+                terminal_ok = .false.
+            end if
         end if
-        print *, trim(display_content)
-        print *, ""
-        print *, "Interactive TUI Mode - Press Ctrl+C to exit"
-        print *, "Frame rate limited to prevent system issues"
+
+        ! Always attempt to print primary content; fail gracefully on error
+        write(*,'(A)',iostat=ios) trim(display_content)
+        if (ios /= 0) then
+            error_msg = "Terminal output failed; unable to render TUI content"
+            goto 100
+        end if
+
+        write(*,'(A)',iostat=ios) ""
+        write(*,'(A)',iostat=ios) "Interactive TUI Mode - Press Ctrl+C to exit"
+        write(*,'(A)',iostat=ios) "Frame rate limited to prevent system issues"
 
         ! Run the TUI main loop with proper controls
-        call tui%run_main_loop(.true., 30.0_real64)  ! Interactive, 30 second max
-
-        ! Clean up
-        if (session%colors_enabled) then
-            print *, char(27)//'[0m'  ! Reset terminal colors
+        if (present(max_runtime_seconds)) then
+            call tui%run_main_loop(.true., max_runtime_seconds)
+        else
+            call tui%run_main_loop(.true.)  ! Use engine default safety limit (5s)
         end if
 
-        call tui%cleanup()
-        success = .true.
+        ! Clean up
+100     continue
+        if (session%colors_enabled .and. terminal_ok) then
+            write(*,'(A)',iostat=ios) char(27)//'[0m'
+        end if
+
+        if (tui_initialized) then
+            call tui%cleanup()
+        end if
+
+        success = (len_trim(error_msg) == 0)
     end subroutine start_interactive_tui
 
 end module tui_manager_core

--- a/test/test_issue_995_tui_manager.f90
+++ b/test/test_issue_995_tui_manager.f90
@@ -1,0 +1,50 @@
+program test_issue_995_tui_manager
+    !! Tests for Issue #995 - TUI manager resource cleanup and error boundaries
+    use iso_fortran_env, only: real64
+    use report_config_core, only: terminal_session_t
+    use tui_manager_core,   only: start_interactive_tui
+    implicit none
+
+    type(terminal_session_t) :: session
+    character(len=:), allocatable :: err
+    logical :: ok
+    real(real64) :: t0, t1, elapsed
+
+    print *, "=========================================="
+    print *, " Issue #995: TUI Manager Robustness Tests"
+    print *, "=========================================="
+
+    ! Test 1: Configurable timeout honored (no 30s hard limit)
+    print *, "Test 1: Configurable max runtime honored"
+    call session%init()
+    session%is_active = .true.
+    session%colors_enabled = .false.
+    call cpu_time(t0)
+    call start_interactive_tui(session, "Test content", ok, err, 0.05_real64)
+    call cpu_time(t1)
+    elapsed = t1 - t0
+    if (ok) then
+        print *, "  PASS: start_interactive_tui returned successfully"
+    else
+        print *, "  FAIL: start_interactive_tui failed: ", trim(err)
+    end if
+    if (elapsed < 1.0_real64) then
+        print *, "  PASS: Runtime bounded (", elapsed, "s)"
+    else
+        print *, "  FAIL: Runtime too long (", elapsed, "s)"
+    end if
+
+    ! Test 2: Session state verification prevents unsafe startup
+    print *, "Test 2: Session state verification"
+    call session%cleanup()
+    session%is_active = .false.
+    session%colors_enabled = .false.
+    call start_interactive_tui(session, "Test content", ok, err, 0.01_real64)
+    if (.not. ok) then
+        print *, "  PASS: Inactive session correctly rejected"
+    else
+        print *, "  FAIL: Inactive session unexpectedly accepted"
+    end if
+
+end program test_issue_995_tui_manager
+

--- a/test/test_issue_995_tui_manager.f90
+++ b/test/test_issue_995_tui_manager.f90
@@ -27,11 +27,13 @@ program test_issue_995_tui_manager
         print *, "  PASS: start_interactive_tui returned successfully"
     else
         print *, "  FAIL: start_interactive_tui failed: ", trim(err)
+        stop 1
     end if
     if (elapsed < 1.0_real64) then
         print *, "  PASS: Runtime bounded (", elapsed, "s)"
     else
         print *, "  FAIL: Runtime too long (", elapsed, "s)"
+        stop 1
     end if
 
     ! Test 2: Session state verification prevents unsafe startup
@@ -44,7 +46,7 @@ program test_issue_995_tui_manager
         print *, "  PASS: Inactive session correctly rejected"
     else
         print *, "  FAIL: Inactive session unexpectedly accepted"
+        stop 1
     end if
 
 end program test_issue_995_tui_manager
-


### PR DESCRIPTION
### **User description**
Problem: TUI manager had hard-coded 30s timeout, no error boundaries around terminal writes, and unconditional cleanup calls.

Solution:
- Add iostat-checked terminal writes with graceful degradation
- Make max runtime configurable via start_interactive_tui optional arg; pass report config startup timeout
- Verify session state before starting; guard cleanup with init flag

Tests:
- New test/test_issue_995_tui_manager.f90 validates configurable runtime and inactive-session rejection
- Ran ./run_ci_tests.sh: all non-excluded tests PASS (86/86), hygiene CLEAN

Evidence:


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add configurable timeout to TUI manager replacing hard-coded 30s limit

- Implement error boundaries around terminal writes with graceful degradation

- Add session state verification and safe cleanup with initialization guards

- Include comprehensive test coverage for timeout and session validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Report Engine"] --> B["TUI Manager"]
  B --> C["Session Validation"]
  C --> D["Terminal I/O with Error Handling"]
  D --> E["Configurable Timeout Loop"]
  E --> F["Safe Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report_engine_terminal.f90</strong><dd><code>Add configurable timeout parameter passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/reporting/report_engine_terminal.f90

<ul><li>Add <code>iso_fortran_env</code> import for <code>real64</code> type<br> <li> Pass configurable timeout from config to <code>start_interactive_tui</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1087/files#diff-42298e7999f2697621546a61ab8ab60029800eae61bc7c1465ab98a059c4f1d1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>report_generator_core.f90</strong><dd><code>Add configurable timeout parameter passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/reporting/report_generator_core.f90

<ul><li>Add <code>iso_fortran_env</code> import for <code>real64</code> type<br> <li> Pass configurable timeout from config to <code>start_interactive_tui</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1087/files#diff-1fbfeab8dc21a20defd933f63d8f99960aa9c4eb2e1901d9e056b26d1ae88032">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tui_manager_core.f90</strong><dd><code>Robust TUI manager with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/tui/tui_manager_core.f90

<ul><li>Add optional <code>max_runtime_seconds</code> parameter to <code>start_interactive_tui</code><br> <li> Implement session state validation before TUI startup<br> <li> Add error boundaries around terminal writes with <code>iostat</code> checking<br> <li> Guard cleanup operations with initialization flag</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1087/files#diff-00b9f49d033429fc796b3e07cef68a94d42b7c430e47140a7eee8b9ef9e0e3ae">+44/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_995_tui_manager.f90</strong><dd><code>Comprehensive TUI manager robustness tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_995_tui_manager.f90

<ul><li>New test program validating configurable runtime limits<br> <li> Test session state verification preventing unsafe startup<br> <li> Measure actual runtime to verify timeout compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1087/files#diff-fb07a8d40d1fa97dd28b8c394d77195eaae68210a2ebf836a92c523fe28db48c">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

