### PR TITLE
fix: USER EXPERIENCE REGRESSION: HTML output fails with empty coverag (fixes #976)

### DIFF
--- a/test/test_html_empty_coverage.f90
+++ b/test/test_html_empty_coverage.f90
@@ -1,0 +1,30 @@
+program test_html_empty_coverage
+    use coverage_model_core
+    use data_transformer_core
+    use report_engine_html
+    use theme_manager_core
+    implicit none
+
+    type(coverage_data_t) :: coverage
+    type(data_transformer_t) :: transformer
+    type(theme_manager_t) :: theme_mgr
+    logical :: success
+    character(len=:), allocatable :: err
+    character(len=*), parameter :: out_path = 'build/test_empty_coverage.html'
+
+    call coverage%init()         ! creates empty files array
+    call transformer%init()
+    call theme_mgr%init()
+
+    call generate_html_report_content(coverage, transformer, theme_mgr, &
+                                      out_path, success, err)
+
+    if (.not. success) then
+        print *, 'HTML generation should succeed on empty coverage. Error: ', trim(err)
+        stop 1
+    else
+        print *, '✅ HTML generation with empty coverage succeeded'
+    end if
+
+end program test_html_empty_coverage
+

--- a/test/test_html_empty_coverage.f90
+++ b/test/test_html_empty_coverage.f90
@@ -9,8 +9,9 @@ program test_html_empty_coverage
     type(data_transformer_t) :: transformer
     type(theme_manager_t) :: theme_mgr
     logical :: success
+    logical :: exists
     character(len=:), allocatable :: err
-    character(len=*), parameter :: out_path = 'build/test_empty_coverage.html'
+    character(len=*), parameter :: out_path = 'test_empty_coverage.html'
 
     call coverage%init()         ! creates empty files array
     call transformer%init()
@@ -23,8 +24,12 @@ program test_html_empty_coverage
         print *, 'HTML generation should succeed on empty coverage. Error: ', trim(err)
         stop 1
     else
-        print *, '✅ HTML generation with empty coverage succeeded'
+        inquire(file=out_path, exist=exists)
+        if (.not. exists) then
+            print *, 'HTML file was not created at: ', trim(out_path)
+            stop 1
+        end if
+        print *, 'OK: HTML generation with empty coverage succeeded'
     end if
 
 end program test_html_empty_coverage
-


### PR DESCRIPTION
### **User description**
Automated fix for issue #976: allow HTML reporting on empty coverage data.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix HTML report generation for empty coverage data

- Remove validation that blocked empty file lists

- Add test to verify empty coverage handling

- Allow graceful processing of uninitialized input


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Empty Coverage Data"] --> B["Data Transformer"]
  B --> C["HTML Report Generator"]
  C --> D["Generated HTML File"]
  E["Validation Removal"] --> B
  F["Test Coverage"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_transformer_core.f90</strong><dd><code>Remove empty coverage validation blocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/system/data_transformer_core.f90

<ul><li>Remove validation that rejected empty file lists<br> <li> Add conditional processing for allocated input files<br> <li> Allow empty coverage data to proceed through transformation<br> <li> Maintain error handling for allocation failures</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1088/files#diff-bc9416d4c3be0db01a690a3956313a4ec8af504b7d0c17e34b31989c05268872">+16/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_html_empty_coverage.f90</strong><dd><code>Add empty coverage HTML test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_html_empty_coverage.f90

<ul><li>Add new test program for empty coverage scenarios<br> <li> Verify HTML report generation succeeds with empty data<br> <li> Check output file existence after generation<br> <li> Provide clear success/failure messaging</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1088/files#diff-ee46cfde4678ba3fac8e93f10fffe310da8f662443199e7c38e5d87e420e6373">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

