### PR TITLE
fix: DEFECT: Exclude patterns cause 'No coverage files found' despite valid gcov files (fixes #884)

### DIFF
--- a/src/coverage/workflows/coverage_workflows_discovery.f90
+++ b/src/coverage/workflows/coverage_workflows_discovery.f90
@@ -188,7 +188,7 @@ contains
         integer, intent(in) :: file_count
         
         if (.not. config%quiet) then
-            print *, "⚠️  Limiting coverage files from", file_count, "to", config%max_files
+            print *, "Limiting coverage files from", file_count, "to", config%max_files
         end if
     end subroutine report_file_count_limit
     
@@ -207,7 +207,7 @@ contains
         end if
         
         copy_size = min(size(files), new_size)
-        allocate(character(len=len(files)) :: temp_files(new_size))
+        allocate(character(len=len(files(1))) :: temp_files(new_size))
         
         do i = 1, copy_size
             temp_files(i) = files(i)

--- a/src/coverage/workflows/coverage_workflows_discovery.f90
+++ b/src/coverage/workflows/coverage_workflows_discovery.f90
@@ -129,18 +129,24 @@ contains
     
     subroutine apply_coverage_file_filtering(all_files, config, filtered_files)
         !! Apply filtering to coverage files if needed
+        !! Issue #884: Exclude patterns must NOT filter .gcov discovery
+        !!             Filtering is applied later to source paths within
+        !!             the parsed coverage data, not to the coverage files
+        !!             themselves. Here we simply pass through discovered
+        !!             coverage files unchanged.
         character(len=:), allocatable, intent(in) :: all_files(:)
         type(config_t), intent(in) :: config
         character(len=:), allocatable, intent(out) :: filtered_files(:)
-        
-        ! Filter files by exclude patterns
-        if (allocated(all_files)) then
-            ! Bypass filtering for empty arrays to avoid allocation issues
-            if (size(all_files) == 0) then
-                allocate(character(len=256) :: filtered_files(0))
-            else
-                filtered_files = filter_coverage_files_by_patterns(all_files, config)
-            end if
+
+        if (.not. allocated(all_files)) then
+            return
+        end if
+
+        if (size(all_files) == 0) then
+            allocate(character(len=256) :: filtered_files(0))
+        else
+            allocate(character(len=len(all_files(1))) :: filtered_files(size(all_files)))
+            filtered_files = all_files
         end if
     end subroutine apply_coverage_file_filtering
     

--- a/test/test_exclude_patterns_filtering_issue_884.f90
+++ b/test/test_exclude_patterns_filtering_issue_884.f90
@@ -1,0 +1,60 @@
+program test_exclude_patterns_filtering_issue_884
+    !! Ensure exclude patterns do not remove valid gcov files (Issue #884)
+    use iso_fortran_env, only: output_unit
+    use config_core, only: config_t, parse_config
+    use coverage_workflows_discovery, only: filter_coverage_files_by_patterns
+    implicit none
+
+    type(config_t) :: config
+    character(len=:), allocatable :: filtered(:)
+    character(len=256) :: files(3)
+    character(len=:), allocatable :: args(:)
+    logical :: success
+    character(len=256) :: error_message
+    integer :: i, keep_count
+    logical :: has_main
+
+    write(output_unit, '(A)') 'Running Issue #884: exclude pattern filtering correctness'
+
+    ! Build CLI-like args with exclude patterns only
+    allocate(character(len=64) :: args(2))
+    args(1) = '--exclude=build/*'
+    args(2) = '--exclude=test/*'
+
+    call parse_config(args, config, success, error_message)
+    if (.not. success) then
+        write(output_unit, '(A)') 'Config parsing failed: ' // trim(error_message)
+        stop 1
+    end if
+
+    ! Simulated discovered coverage files
+    files(1) = 'main.f90.gcov'      ! Should be kept
+    files(2) = 'build/foo.gcov'     ! Should be excluded by build/*
+    files(3) = 'test/bar.gcov'      ! Should be excluded by test/*
+
+    filtered = filter_coverage_files_by_patterns(files, config)
+
+    if (.not. allocated(filtered)) then
+        write(output_unit, '(A)') 'FAIL: Filtering returned unallocated array'
+        stop 1
+    end if
+
+    keep_count = size(filtered)
+    has_main = .false.
+    do i = 1, keep_count
+        if (trim(filtered(i)) == 'main.f90.gcov') has_main = .true.
+        if (index(filtered(i), 'build/') == 1 .or. index(filtered(i), 'test/') == 1) then
+            write(output_unit, '(A)') 'FAIL: Excluded path leaked through filtering: ' // trim(filtered(i))
+            stop 1
+        end if
+    end do
+
+    if (.not. has_main) then
+        write(output_unit, '(A)') 'FAIL: main.f90.gcov was incorrectly excluded'
+        stop 1
+    end if
+
+    write(output_unit, '(A)') 'PASS: Exclude pattern filtering keeps valid gcov files'
+
+end program test_exclude_patterns_filtering_issue_884
+


### PR DESCRIPTION
### **User description**
- Fix discovery workflow to not filter .gcov by exclude patterns
- Add regression test to ensure valid .gcov files are kept when excluding build/* and test/*

Tests: ./run_ci_tests.sh → All non-excluded tests passed locally.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix exclude patterns incorrectly filtering .gcov files during discovery

- Add regression test for issue #884 coverage file filtering

- Replace non-ASCII character in log output

- Improve array allocation using `len(files(1))`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Coverage Discovery"] --> B["Apply Filtering"]
  B --> C["Pass Through .gcov Files"]
  C --> D["Filter Source Paths Later"]
  E["Exclude Patterns"] -.-> F["Skip .gcov Filtering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage_workflows_discovery.f90</strong><dd><code>Remove exclude filtering from .gcov discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coverage/workflows/coverage_workflows_discovery.f90

<ul><li>Remove exclude pattern filtering from .gcov file discovery<br> <li> Add detailed comments explaining the fix for issue #884<br> <li> Replace non-ASCII warning character with ASCII text<br> <li> Fix array allocation to use <code>len(files(1))</code> instead of <code>len(files)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1090/files#diff-6eb31753c23cdb626ef61cb4b0191a49c1f48850a6e26af9ffaf93ff2adec51a">+18/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exclude_patterns_filtering_issue_884.f90</strong><dd><code>Add regression test for exclude pattern filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_exclude_patterns_filtering_issue_884.f90

<ul><li>Add comprehensive regression test for issue #884<br> <li> Test exclude patterns don't remove valid .gcov files<br> <li> Verify filtering behavior with build/* and test/* patterns<br> <li> Include validation for expected files being kept</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1090/files#diff-bdb790fc5b1c71bf71bdaf900480413f19af7e3213bc3d8cf0b6912500e1f499">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

