### PR TITLE
fix: Release workflow YAML syntax error causing pipeline failures (fixes #960)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,9 +155,14 @@ jobs:
         # Copy executable with version-specific name
         cp "${{ env.EXECUTABLE_PATH }}" "release-artifacts/${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}"
         
-        # Create checksums
+        # Create checksums (portable across Linux/macOS)
         cd release-artifacts
-        sha256sum "${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}" > "${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}.sha256"
+        ART="${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}"
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum "$ART" > "$ART.sha256"
+        else
+          shasum -a 256 "$ART" | awk '{print $1}' > "$ART.sha256"
+        fi
         
         echo "✅ Release artifact packaged"
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         include:
         - os: ubuntu-latest
-          artifact-name: fortcov-linux-x86_64
+          artifact_name: fortcov-linux-x86_64
           executable: fortcov
         - os: macos-latest
-          artifact-name: fortcov-macos-x86_64
+          artifact_name: fortcov-macos-x86_64
           executable: fortcov
     
     steps:
@@ -153,18 +153,18 @@ jobs:
         mkdir -p release-artifacts
         
         # Copy executable with version-specific name
-        cp "${{ env.EXECUTABLE_PATH }}" "release-artifacts/${{ matrix.artifact-name }}-${{ needs.validate-version.outputs.version }}"
+        cp "${{ env.EXECUTABLE_PATH }}" "release-artifacts/${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}"
         
         # Create checksums
         cd release-artifacts
-        sha256sum "${{ matrix.artifact-name }}-${{ needs.validate-version.outputs.version }}" > "${{ matrix.artifact-name }}-${{ needs.validate-version.outputs.version }}.sha256"
+        sha256sum "${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}" > "${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}.sha256"
         
         echo "✅ Release artifact packaged"
         
     - name: Upload release artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.artifact-name }}-${{ needs.validate-version.outputs.version }}
+        name: ${{ matrix.artifact_name }}-${{ needs.validate-version.outputs.version }}
         path: release-artifacts/
         retention-days: 30
 


### PR DESCRIPTION
### **User description**
Fix release workflow expressions by renaming matrix keys from artifact-name to artifact_name and updating references to avoid invalid hyphenated identifiers. Evidence: local YAML parse OK; project tests pass via ./run_ci_tests.sh. No code changes.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix YAML syntax error in release workflow matrix keys

- Replace hyphenated `artifact-name` with `artifact_name` 

- Add portable SHA256 generation for macOS compatibility

- Update all matrix key references consistently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Matrix Definition"] -- "rename keys" --> B["artifact_name"]
  B -- "update references" --> C["Package Step"]
  C -- "add portability" --> D["SHA256 Generation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix workflow syntax and macOS compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Rename matrix keys from <code>artifact-name</code> to <code>artifact_name</code><br> <li> Update all references to use underscored key names<br> <li> Replace <code>sha256sum</code> with portable SHA256 generation logic<br> <li> Add macOS compatibility using <code>shasum</code> command fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1092/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

