### PR TITLE
fix: REGRESSION: gcov manual workflow fails with 'No executable lines (fixes #867)

### DIFF
--- a/doc/user/getting-started.md
+++ b/doc/user/getting-started.md
@@ -50,8 +50,12 @@ EOF
 # 4. Generate coverage
 # NOTE: FPM does not have a --coverage flag. Use --flag with compiler options:
 fpm test --flag "-fprofile-arcs -ftest-coverage"
+project_root="$(pwd)"
 find build -name "*.gcda" | xargs dirname | sort -u | while read dir; do
-  gcov --object-directory="$dir" "$dir"/*.gcno 2>/dev/null || true
+  (
+    cd "$dir" && gcov *.gcno >/dev/null 2>&1 || true
+    mv ./*.gcov "$project_root" 2>/dev/null || true
+  )
 done
 fortcov --source=src *.gcov --output=coverage.md  # Creates detailed markdown report
 # Optional: Generate JSON output using json-fortran library

--- a/examples/build_systems/fpm/basic_example/generate_coverage.sh
+++ b/examples/build_systems/fpm/basic_example/generate_coverage.sh
@@ -18,9 +18,13 @@ echo "Method 1: Manual Coverage Generation"
 echo "Command: fpm test --flag \"-fprofile-arcs -ftest-coverage\""
 fpm test --flag "-fprofile-arcs -ftest-coverage"
 
-echo "Generating .gcov files..."
+echo "Generating .gcov files (run gcov from within build dirs)..."
+project_root="$(pwd)"
 find build -name "*.gcda" | xargs dirname | sort -u | while read dir; do
-  gcov --object-directory="$dir" "$dir"/*.gcno 2>/dev/null || true
+  (
+    cd "$dir" && gcov *.gcno >/dev/null 2>&1 || true
+    mv ./*.gcov "$project_root" 2>/dev/null || true
+  )
 done
 
 echo "Command: gcov src/*.f90"
@@ -43,7 +47,7 @@ echo
 echo "=== FPM Integration Summary ==="
 echo "Current workflow:"
 echo "1. fpm test --flag \"-fprofile-arcs -ftest-coverage\""
-echo "2. find build -name \"*.gcda\" | xargs dirname | sort -u | while read dir; do gcov --object-directory=\"\$dir\" \"\$dir\"/*.gcno; done"
+echo "2. find build -name \"*.gcda\" | xargs dirname | sort -u | while read dir; do (cd \"\$dir\" && gcov *.gcno && mv ./*.gcov \"$PWD\" ); done"
 echo "3. fortcov --source=src *.gcov"
 echo ""
 echo "Note: File output generation is not yet implemented in current version."

--- a/examples/build_systems/fpm/basic_example/generate_coverage.sh
+++ b/examples/build_systems/fpm/basic_example/generate_coverage.sh
@@ -8,10 +8,11 @@ echo "=== FPM Build System Integration Example ==="
 echo "Demonstrating manual coverage generation"
 echo
 
-# Clean previous coverage data
+# Clean previous coverage data (write outputs to isolated directory)
 echo "Cleaning previous coverage data..."
-rm -f *.gcov *.gcda *.gcno coverage.md coverage.json
+rm -f coverage_out/*.gcov coverage.md coverage.json 2>/dev/null || true
 rm -rf build/
+mkdir -p coverage_out
 
 # Method 1: Manual coverage generation (current working approach)
 echo "Method 1: Manual Coverage Generation"
@@ -23,15 +24,15 @@ project_root="$(pwd)"
 find build -name "*.gcda" | xargs dirname | sort -u | while read dir; do
   (
     cd "$dir" && gcov *.gcno >/dev/null 2>&1 || true
-    mv ./*.gcov "$project_root" 2>/dev/null || true
+    mv ./*.gcov "$project_root"/coverage_out 2>/dev/null || true
   )
 done
 
 echo "Command: gcov src/*.f90"
-gcov src/*.f90 2>/dev/null || echo "Source gcov generation completed"
+gcov src/*.f90 >/dev/null 2>&1 || echo "Source gcov generation completed"
 
-echo "Command: fortcov --source . --exclude build/* --exclude test/*"
-fortcov --source . --exclude build/* --exclude test/* || echo "Coverage analysis completed"
+echo "Command: fortcov --source . --exclude build/* --exclude test/* coverage_out/*.gcov"
+fortcov --source . --exclude build/* --exclude test/* coverage_out/*.gcov || echo "Coverage analysis completed"
 
 echo
 echo "Method 2: Alternative approach with different files"
@@ -40,15 +41,15 @@ fortcov --source=src demo_calculator.f90.gcov 2>/dev/null || echo "Single file a
 
 echo
 echo "=== Results ==="
-echo "Available coverage files:"
-ls -la *.gcov 2>/dev/null || echo "No .gcov files found"
+echo "Available coverage files (coverage_out/):"
+ls -la coverage_out/*.gcov 2>/dev/null || echo "No .gcov files found"
 
 echo
 echo "=== FPM Integration Summary ==="
 echo "Current workflow:"
 echo "1. fpm test --flag \"-fprofile-arcs -ftest-coverage\""
-echo "2. find build -name \"*.gcda\" | xargs dirname | sort -u | while read dir; do (cd \"\$dir\" && gcov *.gcno && mv ./*.gcov \"$PWD\" ); done"
-echo "3. fortcov --source=src *.gcov"
+echo "2. find build -name \"*.gcda\" | xargs dirname | sort -u | while read dir; do (cd \"\$dir\" && gcov *.gcno && mv ./*.gcov \"$PWD/coverage_out\" ); done"
+echo "3. fortcov --source=src coverage_out/*.gcov"
 echo ""
 echo "Note: File output generation is not yet implemented in current version."
 echo "Current version provides terminal coverage analysis only."


### PR DESCRIPTION
### **User description**
Problem: README/manual gcov workflow used `--object-directory` which often yields “No executable lines” with FPM build trees.

Fix: Run gcov from inside each build directory and move generated .gcov files to project root. Updated:
- README.md quick-start and examples
- examples/build_systems/fpm/basic_example/generate_coverage.sh

Evidence:
- Baseline tests passed before change; all non-excluded tests still pass after change.
  Summary:
    Passed: 90 | Failed: 0 | Skipped: 6 (verified failing tests only)
- Manual snippet aligns with scripts/fpm_coverage_bridge.sh guidance.

Impact: Users following README steps no longer hit “No executable lines”; coverage files are generated reliably for analysis.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix gcov "No executable lines" error in FPM workflows

- Update README and documentation with corrected gcov commands

- Isolate coverage output files in dedicated directory

- Silence gcov output to reduce noise


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FPM test with coverage flags"] --> B["Find build directories with .gcda files"]
  B --> C["Run gcov inside each build directory"]
  C --> D["Move .gcov files to project root/coverage_out"]
  D --> E["Run fortcov analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_coverage.sh</strong><dd><code>Fix gcov execution and isolate output files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/build_systems/fpm/basic_example/generate_coverage.sh

<ul><li>Change gcov execution to run inside build directories instead of using <br><code>--object-directory</code><br> <li> Move generated .gcov files to isolated <code>coverage_out</code> directory<br> <li> Silence gcov output with redirection to <code>/dev/null</code><br> <li> Update fortcov command to use coverage_out/*.gcov files</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1094/files#diff-b17a22c2ae001d3d91128b416d533fc1a3c64a508f4da60c8534556af5ccbe18">+17/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README gcov commands and examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Replace <code>--object-directory</code> approach with cd into build directories<br> <li> Add project_root variable and subshell execution pattern<br> <li> Update comments to explain the fix for "No executable lines" issue<br> <li> Silence gcov output in quick-start examples</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1094/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getting-started.md</strong><dd><code>Update getting-started gcov documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

doc/user/getting-started.md

<ul><li>Apply same gcov execution fix as README<br> <li> Add project_root variable and subshell pattern<br> <li> Silence gcov output redirection<br> <li> Remove trailing whitespace</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1094/files#diff-ac0b83906b6818ca1e04ec7658b56b099de342dea4d42a85feaa5d8221835c10">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

