### PR TITLE
fix: BUFFER OVERFLOW RISK: Hardcoded 256-char buffers throughout code (fixes #726)

### DIFF
--- a/test/test_issue_726_buffer_length_safety.f90
+++ b/test/test_issue_726_buffer_length_safety.f90
@@ -1,0 +1,34 @@
+program test_issue_726_buffer_length_safety
+    !! Validate empty result buffer length is minimal (Issue #726)
+    use config_core, only: config_t, initialize_config
+    use coverage_processor_gcov, only: discover_gcov_files
+    use iso_fortran_env, only: output_unit
+    implicit none
+
+    type(config_t) :: config
+    character(len=:), allocatable :: files(:)
+
+    call initialize_config(config)
+    config%quiet = .true.
+
+    call discover_gcov_files(config, files)
+
+    if (.not. allocated(files)) then
+        write(output_unit,'(A)') '✗ files not allocated'
+        stop 1
+    end if
+
+    if (size(files) /= 0) then
+        write(output_unit,'(A,I0)') '✗ expected empty files, size=', size(files)
+        stop 1
+    end if
+
+    if (len(files) /= 1) then
+        write(output_unit,'(A,I0)') '✗ expected element length 1, got ', len(files)
+        stop 1
+    end if
+
+    write(output_unit,'(A)') '✓ Issue #726 buffer length safety validated'
+
+end program test_issue_726_buffer_length_safety
+


### PR DESCRIPTION
### **User description**
Implements minimal buffer-length safety for gcov processor internals to address #726.\n\n- Changes: dynamic path handling and minimal-length empty arrays.\n- Tests: added test_issue_726_buffer_length_safety; full CI suite passes locally.\n\nEvidence: ./run_ci_tests.sh → Passed with 6 verified skips.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace hardcoded 256/500-char buffers with dynamic allocation

- Implement secure directory and file operations

- Add minimal-length empty array allocation (length=1)

- Remove shell command vulnerabilities in gcov processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Buffers"] --> B["Dynamic Allocation"]
  C["Shell Commands"] --> D["Secure Operations"]
  E["Large Empty Arrays"] --> F["Minimal Length Arrays"]
  B --> G["Buffer Safety"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage_processor_gcov.f90</strong><dd><code>Replace hardcoded buffers with dynamic allocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coverage/processors/coverage_processor_gcov.f90

<ul><li>Remove hardcoded <code>character(len=500)</code> and <code>character(len=1000)</code> buffer <br>declarations<br> <li> Replace with dynamic allocation using exact string lengths<br> <li> Change empty array allocation from <code>len=256</code> to <code>len=1</code> for minimal memory <br>usage<br> <li> Implement secure directory creation and file operations without shell <br>commands<br> <li> Remove non-ASCII warning emoji and replace with standard text</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1098/files#diff-79447fd4ecf6f08bf159bb5c723094cd10a5da84ff58fd05f885a3941743ac02">+50/-74</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_726_buffer_length_safety.f90</strong><dd><code>Add buffer length safety validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_726_buffer_length_safety.f90

<ul><li>Add new test program to validate buffer length safety<br> <li> Test empty array allocation returns minimal length (1 character)<br> <li> Verify <code>discover_gcov_files</code> returns properly allocated empty arrays<br> <li> Include validation for array size and element length</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortcov/pull/1098/files#diff-a5b134d12c28e06bf6697c26d12fd2feed976d35b66d1a0da23e62c337d5ef58">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

