### PR TITLE
fix: Enforce 'use, only:' in xml_attribute_parser (fixes #1115)

### DIFF
--- a/src/reporters/xml_attribute_parser.f90
+++ b/src/reporters/xml_attribute_parser.f90
@@ -9,7 +9,7 @@ module xml_attribute_parser
     !! - Comprehensive error handling for all allocations
     !! - Safe deallocation patterns with stat= checking
     !! - Proper error reporting for memory failures
-    use coverage_model_core
+    use coverage_model_core, only: coverage_line_t
     implicit none
     private
     


### PR DESCRIPTION
This PR restricts the import in src/reporters/xml_attribute_parser.f90 to the actually used symbol (coverage_line_t), aligning with repo import rules. Verified with ./run_ci_tests.sh (all passing).