### PR TITLE
fix: align license to MIT in CLI and add LICENSE (fixes #1121)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 lazy-fortran contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/config/help/config_help_core.f90
+++ b/src/config/help/config_help_core.f90
@@ -88,7 +88,7 @@ contains
         print *, "  - Parallel processing: not implemented (threads flag ignored)"
         print *, ""
         print *, "Repository: https://github.com/lazy-fortran/fortcov"
-        print *, "License: Apache-2.0"
+        print *, "License: MIT"
 
     end subroutine show_version_information
 


### PR DESCRIPTION
Align CLI help/version to MIT and add LICENSE file. Fixes #1121.