### PR TITLE
fix: bug: fix logging glitches (newline in discovery; duplicate build-system line) (fixes #1123)

### DIFF
--- a/src/coverage/utils/coverage_build.f90
+++ b/src/coverage/utils/coverage_build.f90
@@ -8,10 +8,8 @@ module coverage_build
     use config_core
     use build_detector_core
     use build_system_validation, only: detect_and_validate_build_system, &
-                                       report_build_detection_failed, &
                                        report_unknown_build_system, &
-                                       report_build_tool_unavailable, &
-                                       report_build_system_detected
+                                       report_build_tool_unavailable
     use error_handling_core
     implicit none
     private

--- a/src/coverage/utils/coverage_build.f90
+++ b/src/coverage/utils/coverage_build.f90
@@ -51,8 +51,8 @@ contains
             exit_code = 3  ! Coverage support validation failed
             return
         end if
-        
-        call report_build_system_detected(config, build_info)
+        ! Successful detection already reported by detect_and_validate_build_system
+        ! Avoid duplicate reporting here
         
     end function detect_and_validate_build_system_for_coverage
 

--- a/src/zero_config/zero_config_core.f90
+++ b/src/zero_config/zero_config_core.f90
@@ -252,8 +252,8 @@ contains
         
         if (.not. config%quiet) then
             if (allocated(discovered_coverage_files)) then
-                print '(A,I0)', "FortCov: Discovery returned ", &
-                                  size(discovered_coverage_files), " files"
+                print '(A,I0,A)', "FortCov: Discovery returned ", &
+                                   size(discovered_coverage_files), " files"
             else
                 print '(A)', "FortCov: Discovery returned no allocated array"
             end if

--- a/test/test_logging_glitches_1123.f90
+++ b/test/test_logging_glitches_1123.f90
@@ -1,0 +1,39 @@
+program test_logging_glitches_1123
+    !! Smoke test for logging formatting (Issue #1123)
+    !! Verifies discovery message uses single-line formatting without spurious newline.
+
+    use iso_fortran_env, only: output_unit
+    implicit none
+
+    integer :: tests = 0
+    integer :: passed = 0
+
+    call test_discovery_message_format()
+
+    write(output_unit,'(A,I0,A,I0,A)') 'Test Results: ', passed, ' / ', tests, ' passed'
+    if (passed /= tests) stop 1
+
+contains
+
+    subroutine test_discovery_message_format()
+        character(len=256) :: buf
+        character(len=*), parameter :: expected = 'FortCov: Discovery returned 249 files'
+        integer :: i
+
+        tests = tests + 1
+
+        ! Correct formatting: all parts in a single WRITE with (A,I0,A)
+        write(buf, '(A,I0,A)') 'FortCov: Discovery returned ', 249, ' files'
+
+        if (index(buf, new_line('a')) == 0 .and. trim(buf) == expected) then
+            passed = passed + 1
+            write(output_unit,'(A)') '  ✓ Discovery message formatted on a single line'
+        else
+            write(output_unit,'(A)') '  ✗ Discovery message formatting contains newline or mismatch'
+            write(output_unit,'(A,A)') '    Expected: ', expected
+            write(output_unit,'(A,A)') '    Actual:   ', trim(buf)
+        end if
+    end subroutine test_discovery_message_format
+
+end program test_logging_glitches_1123
+

--- a/test/test_logging_glitches_1123.f90
+++ b/test/test_logging_glitches_1123.f90
@@ -18,7 +18,6 @@ contains
     subroutine test_discovery_message_format()
         character(len=256) :: buf
         character(len=*), parameter :: expected = 'FortCov: Discovery returned 249 files'
-        integer :: i
 
         tests = tests + 1
 

--- a/test/test_logging_glitches_1123.f90
+++ b/test/test_logging_glitches_1123.f90
@@ -26,13 +26,12 @@ contains
 
         if (index(buf, new_line('a')) == 0 .and. trim(buf) == expected) then
             passed = passed + 1
-            write(output_unit,'(A)') '  ✓ Discovery message formatted on a single line'
+            write(output_unit,'(A)') '  [PASS] Discovery message formatted on a single line'
         else
-            write(output_unit,'(A)') '  ✗ Discovery message formatting contains newline or mismatch'
+            write(output_unit,'(A)') '  [FAIL] Discovery message formatting contains newline or mismatch'
             write(output_unit,'(A,A)') '    Expected: ', expected
             write(output_unit,'(A,A)') '    Actual:   ', trim(buf)
         end if
     end subroutine test_discovery_message_format
 
 end program test_logging_glitches_1123
-


### PR DESCRIPTION
Implements fixes for #1123: single-line discovery message formatting and removal of duplicate build system detection log. Adds a small formatting smoke test.