### PR TITLE
fix: docs: align README example with actual markdown output (fixes #1124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Exit codes: `0` success, `2` threshold not met, `3` no coverage data.
 
 ```bash
 $ fortcov --source=src *.gcov --output=coverage.md
-Coverage Statistics:
-  Line Coverage:  72.9%
-  Lines Covered: 51 of 70 lines
+| Filename | Stmts | Covered | Cover | Missing |
+|----------|-------|---------|-------|---------|
+| src/example.f90 | 10 | 7 | 70.00% | 3-4, 9 |
+| TOTAL    | 10 | 7 | 70.00% | |
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ fortcov --source=src *.gcov --output=coverage.md
 | Filename | Stmts | Covered | Cover | Missing |
 |----------|-------|---------|-------|---------|
 | src/example.f90 | 10 | 7 | 70.00% | 3-4, 9 |
-| TOTAL    | 10 | 7 | 70.00% | |
+| TOTAL | 10 | 7 | 70.00% | |
 ```
 
 ## Notes


### PR DESCRIPTION
Align README example with actual markdown table output. Updates only documentation; tests pass locally.