### PR TITLE
fix: enhancement: add built-in FPM gcov bridge mode (--gcov) (fixes #1125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # FortCov – Precise FPM Coverage
 
-FortCov turns gfortran/gcov coverage into clear reports. It analyzes `.gcov`
-files produced by `gcov`; it does not invoke `gcov` itself. For FPM builds,
-use `gcov` (or the helper scripts in `scripts/`) to generate `.gcov` files,
-then run FortCov to create the report.
+FortCov turns gfortran/gcov coverage into clear reports. By default it analyzes
+existing `.gcov` files. You can also use the built-in bridge with `--gcov` to
+auto-discover FPM/CMake build dirs and generate `.gcov` from coverage artifacts
+before analysis. For manual control, use `gcov` (or helper scripts in
+`scripts/`) to generate `.gcov`, then run FortCov to create the report.
 
 See the consolidated coverage workflow: `doc/coverage_workflow.md`.
 
@@ -77,6 +78,13 @@ $ fortcov --source=src *.gcov --output=coverage.md
 |----------|-------|---------|-------|---------|
 | src/example.f90 | 10 | 7 | 70.00% | 3-4, 9 |
 | TOTAL | 10 | 7 | 70.00% | |
+```
+
+Or with the built-in bridge:
+
+```bash
+$ fortcov --gcov --output=coverage.md
+# Auto-discovers build dirs, generates .gcov, and produces coverage.md
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # FortCov – Precise FPM Coverage
 
 FortCov turns gfortran/gcov coverage into clear reports. By default it analyzes
-existing `.gcov` files. You can also use the built-in bridge with `--gcov` to
-auto-discover FPM/CMake build dirs and generate `.gcov` from coverage artifacts
-before analysis. For manual control, use `gcov` (or helper scripts in
-`scripts/`) to generate `.gcov`, then run FortCov to create the report.
+existing `.gcov` files. You can also use the built-in bridge with `--gcov`
+(alias: `--discover-and-gcov`) to auto-discover FPM/CMake build dirs and
+generate `.gcov` from coverage artifacts before analysis. For manual control,
+use `gcov` (or helper scripts in `scripts/`) to generate `.gcov`, then run
+FortCov to create the report.
 
 See the consolidated coverage workflow: `doc/coverage_workflow.md`.
 
@@ -83,7 +84,7 @@ $ fortcov --source=src *.gcov --output=coverage.md
 Or with the built-in bridge:
 
 ```bash
-$ fortcov --gcov --output=coverage.md
+$ fortcov --gcov --output=coverage.md  # alias: --discover-and-gcov
 # Auto-discovers build dirs, generates .gcov, and produces coverage.md
 ```
 

--- a/doc/coverage_workflow.md
+++ b/doc/coverage_workflow.md
@@ -4,7 +4,9 @@ This document provides a single, canonical coverage workflow for FPM-based
 projects. It consolidates prior guidance and ensures copy-paste runnable
 commands.
 
-FortCov consumes `.gcov` files produced by `gcov`; it does not invoke `gcov` itself.
+FortCov consumes `.gcov` files produced by `gcov`. It can also auto-discover
+build directories and generate `.gcov` via the built-in bridge when invoked
+with `--gcov` (alias: `--discover-and-gcov`).
 
 ## Options
 
@@ -12,26 +14,33 @@ FortCov consumes `.gcov` files produced by `gcov`; it does not invoke `gcov` its
   typical steps and then FortCov. Best for CI and local use.
 - Manual steps: Equivalent explicit commands if you prefer not to use scripts.
 
-## A) Bridge Script (Recommended)
+## A) Built-in Bridge (Recommended)
 
 Requirements: `gfortran`, `gcov`, `fpm`.
 
 From the root of your FPM project:
 
 ```bash
+## Option 1: FortCov built-in
+
+```bash
+# Auto-discover build dirs, generate .gcov, produce coverage.md
+fortcov --gcov --output=coverage.md  # alias: --discover-and-gcov
+```
+
+## Option 2: Bridge scripts
+
+```bash
 # Generate application coverage end-to-end and write coverage.md
 ./scripts/fpm_coverage_workflow_fixed.sh coverage.md src
 
-# Note: If `./scripts/fpm_coverage_workflow_fixed.sh` is not present in your
-# project, copy it from the FortCov repository's `scripts/` directory or invoke
-# it via a full path to that script.
-
 # Or: quick bridge that assumes you already produced .gcda/.gcno
 ./scripts/fpm_coverage_bridge.sh src
+```
 
-# Note: If `./scripts/fpm_coverage_bridge.sh` is not present in your project,
-# copy it from the FortCov repository's `scripts/` directory or invoke it via a
-# full path to that script.
+Notes:
+- If a script is not present in your project, copy it from this repository's
+  `scripts/` directory or run it via a full path from the FortCov repository.
 ```
 
 Outputs:
@@ -76,7 +85,8 @@ done
 fortcov --fail-under 80 --source=src *.gcov --output=coverage.md --quiet
 ```
 
-## Future: Built-in auto-gcov
+## Notes on built-in bridge
 
-An integrated "auto-gcov" mode may be added to FortCov in the future. Until
-then, prefer the bridge scripts above or use the manual steps.
+The built-in bridge uses safe, internal discovery and does not execute user-
+provided `gcov` commands. Prefer `--gcov` for the simplest setup, and use the
+bridge scripts or manual steps when you need explicit control.

--- a/src/config/help/config_help_core.f90
+++ b/src/config/help/config_help_core.f90
@@ -19,8 +19,9 @@ contains
         print '(A)', ""
         print '(A)', "Usage: fortcov [OPTIONS] [COVERAGE_FILES...]"
         print '(A)', ""
-        print '(A)', "Note: FortCov analyzes .gcov files; it does not run gcov."
-        print '(A)', "      Generate .gcov with gcov (or scripts/fpm_coverage_bridge.sh) first."
+        print '(A)', "Note: By default, FortCov analyzes existing .gcov files and"
+        print '(A)', "      does not invoke gcov. Use --gcov to auto-discover builds"
+        print '(A)', "      and generate .gcov from coverage artifacts when needed."
         print '(A)', ""
         print '(A)', "Options:"
         print '(A)', "  -h, --help                Show this help message and exit"
@@ -33,8 +34,8 @@ contains
         print '(A)', "  -e, --exclude PATTERN     Exclude files matching pattern"
         print '(A)', "  -i, --include PATTERN     Include only files matching pattern"
         print '(A)', "  --import FILE             Import coverage data from JSON/XML file"
-        ! SECURITY FIX Issue #963: --gcov-executable REMOVED - shell injection vulnerability
-        ! FortCov does not invoke gcov; gcov-related invocation flags removed
+        ! SECURITY: No user-defined gcov executable flag; FortCov uses a
+        ! built-in safe path when --gcov is specified. External overrides removed.
         print '(A)', ""
         print '(A)', "Output Options:"
         print '(A)', "  -o, --output PATH         Output file path"
@@ -57,6 +58,8 @@ contains
         print '(A)', "Auto-Discovery Options:"
         print '(A)', "  --auto-discovery          Enable auto-discovery of sources (default)"
         print '(A)', "  --no-auto-discovery       Disable auto-discovery"
+        print '(A)', "  --gcov                    Discover build dirs and generate .gcov"
+        print '(A)', "  --discover-and-gcov       Alias for --gcov"
         print '(A)', "  --auto-test               Enable automatic test execution (default)"
         print '(A)', "  --no-auto-test            Disable automatic test execution"
         print '(A)', "  --test-timeout SECONDS    Test execution timeout in seconds (default: 300)"
@@ -71,6 +74,7 @@ contains
         print '(A)', "  fortcov --source=src *.gcov             # Analyze gcov files with source"
         print '(A)', "  fortcov --source=src *.gcov --output=report.md # Generate markdown report"
         print '(A)', "  fortcov --source=. *.gcov --format=json        # JSON output format"
+        print '(A)', "  fortcov --gcov --output=coverage.md     # Auto-generate .gcov then analyze"
         print '(A)', ""
         print '(A)', "For more information, visit: https://github.com/lazy-fortran/fortcov"
 

--- a/src/config/parsers/config_parser_flags.f90
+++ b/src/config/parsers/config_parser_flags.f90
@@ -44,7 +44,8 @@ contains
          case ("--help", "-h", "--version", "-V", "--quiet", "-q", &
                "--verbose", "-v", "--validate", "--validate-architecture", "--diff", "--lcov", &
                "--auto-test", "--no-auto-test", "--auto-discovery", &
-               "--no-auto-discovery", "--zero-config", "--tui", "--fail-on-size-warnings")
+               "--no-auto-discovery", "--zero-config", "--tui", "--fail-on-size-warnings", &
+               "--gcov", "--discover-and-gcov")
              requires_value = .false.
         end select
     end function flag_requires_value
@@ -287,6 +288,10 @@ contains
               config%fail_on_size_warnings = .true.
           case ("--zero-config")
               config%zero_configuration_mode = .true.
+          case ("--gcov", "--discover-and-gcov")
+              ! Enable explicit gcov discovery/generation path by disabling
+              ! generic auto-discovery. This routes discovery to gcov processor.
+              config%auto_discovery = .false.
           case default
             ! Unknown flag - reject with error message
             success = .false.

--- a/test/test_cli_flag_gcov_mode.f90
+++ b/test/test_cli_flag_gcov_mode.f90
@@ -1,0 +1,70 @@
+program test_cli_flag_gcov_mode
+    !! Tests for the --gcov / --discover-and-gcov CLI flags
+    !! Ensures flags route discovery to gcov processor by disabling
+    !! generic auto-discovery.
+
+    use iso_fortran_env, only: output_unit
+    use config_core, only: config_t, parse_config
+    use test_utils_core, only: assert_test, reset_test_counters, &
+                               print_test_header, print_test_summary
+    implicit none
+
+    call reset_test_counters()
+    call print_test_header("CLI --gcov flag")
+
+    call test_gcov_flag_disables_auto_discovery()
+    call test_gcov_alias_disables_auto_discovery()
+    call test_default_keeps_auto_discovery()
+
+    call print_test_summary("CLI --gcov flag")
+
+contains
+
+    subroutine test_gcov_flag_disables_auto_discovery()
+        type(config_t) :: config
+        character(len=32), allocatable :: args(:)
+        logical :: success
+        character(len=256) :: error_message
+
+        allocate(character(len=32) :: args(1))
+        args(1) = "--gcov"
+
+        call parse_config(args, config, success, error_message)
+        call assert_test(success, "--gcov parses", "Should parse: " // trim(error_message))
+        if (success) then
+            call assert_test(.not. config%auto_discovery, "--gcov disables auto-discovery", "Should be false")
+        end if
+    end subroutine test_gcov_flag_disables_auto_discovery
+
+    subroutine test_gcov_alias_disables_auto_discovery()
+        type(config_t) :: config
+        character(len=32), allocatable :: args(:)
+        logical :: success
+        character(len=256) :: error_message
+
+        allocate(character(len=32) :: args(1))
+        args(1) = "--discover-and-gcov"
+
+        call parse_config(args, config, success, error_message)
+        call assert_test(success, "--discover-and-gcov parses", "Should parse: " // trim(error_message))
+        if (success) then
+            call assert_test(.not. config%auto_discovery, "alias disables auto-discovery", "Should be false")
+        end if
+    end subroutine test_gcov_alias_disables_auto_discovery
+
+    subroutine test_default_keeps_auto_discovery()
+        type(config_t) :: config
+        character(len=1), allocatable :: no_args(:)
+        logical :: success
+        character(len=256) :: error_message
+
+        allocate(character(len=1) :: no_args(0))
+        call parse_config(no_args, config, success, error_message)
+        call assert_test(success, "no-arg parses", "Should parse: " // trim(error_message))
+        if (success) then
+            call assert_test(config%auto_discovery, "default auto-discovery true", "Should be true")
+        end if
+    end subroutine test_default_keeps_auto_discovery
+
+end program test_cli_flag_gcov_mode
+


### PR DESCRIPTION
Implements a minimal built-in FPM gcov bridge via new CLI flags:\n\n- --gcov / --discover-and-gcov: disables generic auto-discovery and routes discovery to the gcov processor, which auto-discovers build dirs and generates .gcov from coverage artifacts (uses safe built-ins; no user gcov exec overrides).\n- Help and README updated with examples and flag docs.\n- Added test: test/test_cli_flag_gcov_mode.f90 to validate flag behavior.\n\nBaseline and post-change tests pass using ./run_ci_tests.sh within 120s timeout.\n\nThis keeps scope minimal and leverages existing modules (coverage_processor_gcov, gcov_generation_utils).