### PR TITLE
fix: harden CI hygiene script flags (fixes #1150)

### DIFF
--- a/scripts/ci_hygiene_cleanup.sh
+++ b/scripts/ci_hygiene_cleanup.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # CI Hygiene Cleanup Script - Comprehensive test artifact removal
-# 
+#
 # This script ensures CI environments maintain clean project root by
 # removing all possible test artifacts that could contaminate the workspace.
 
-set -e
+# Harden shell behavior: abort on any error, unset var, or pipeline failure
+set -Eeuo pipefail
 
 echo "CI Hygiene Cleanup: Comprehensive test artifact removal"
 


### PR DESCRIPTION
Summary
- Enforce `set -Eeuo pipefail` in `scripts/ci_hygiene_cleanup.sh` to prevent silent failures from unset variables or pipeline errors.

Scope
- File touched: `scripts/ci_hygiene_cleanup.sh` only. No behavior changes to core Fortran code.

Verification
- Ran `TEST_TIMEOUT=120 ./run_ci_tests.sh` locally: All 114 tests passed, 0 failed, 0 skipped. Final hygiene reported CLEAN.
- No new artifacts created; cleanup script still reports success and removes none when clean.

Rationale
- The cleanup script is part of CI hygiene. Using only `set -e` can miss failures in pipelines or from unset variables, leading to false “clean” states. Hardening the shell flags reduces risk without impacting functionality.
