### PR TITLE
fix: get_base_name: handle hidden dotfiles (fixes #1154)

### DIFF
--- a/src/reporters/xml_utility_helpers.f90
+++ b/src/reporters/xml_utility_helpers.f90
@@ -29,19 +29,21 @@ contains
     function get_base_name(filename) result(base_name)
         character(len=*), intent(in) :: filename
         character(len=:), allocatable :: base_name
-        integer :: last_slash, last_dot
+        integer :: last_slash, last_dot, name_start
         
         last_slash = index(filename, '/', back=.true.)
         last_dot = index(filename, '.', back=.true.)
         
-        if (last_slash > 0 .and. last_dot > last_slash) then
-            base_name = filename(last_slash+1:last_dot-1)
-        else if (last_slash > 0) then
-            base_name = filename(last_slash+1:)
-        else if (last_dot > 0) then
-            base_name = filename(1:last_dot-1)
+        if (last_slash > 0) then
+            name_start = last_slash + 1
         else
-            base_name = filename
+            name_start = 1
+        end if
+        
+        if (last_dot > name_start) then
+            base_name = filename(name_start:last_dot-1)
+        else
+            base_name = filename(name_start:)
         end if
         
     end function get_base_name

--- a/src/reporters/xml_utils_core.f90
+++ b/src/reporters/xml_utils_core.f90
@@ -3,8 +3,6 @@ module xml_utils_core
     !! 
     !! Extracted from xml_utils.f90 for SRP compliance (Issue #718).
     !! Handles utility functions for XML processing and file operations.
-    use coverage_model_core
-    use string_utils, only: int_to_string
     use timestamp_utils, only: get_current_timestamp
     implicit none
     private

--- a/src/reporters/xml_utils_core.f90
+++ b/src/reporters/xml_utils_core.f90
@@ -33,19 +33,25 @@ contains
     function get_base_name(filename) result(base_name)
         character(len=*), intent(in) :: filename
         character(len=:), allocatable :: base_name
-        integer :: last_slash, last_dot
+        integer :: last_slash, last_dot, name_start
         
         last_slash = index(filename, '/', back=.true.)
         last_dot = index(filename, '.', back=.true.)
         
-        if (last_slash > 0 .and. last_dot > last_slash) then
-            base_name = filename(last_slash+1:last_dot-1)
-        else if (last_slash > 0) then
-            base_name = filename(last_slash+1:)
-        else if (last_dot > 0) then
-            base_name = filename(1:last_dot-1)
+        ! Determine start of the name component (after the last slash, if any)
+        if (last_slash > 0) then
+            name_start = last_slash + 1
         else
-            base_name = filename
+            name_start = 1
+        end if
+        
+        ! If the dot is after the start of the name, treat as extension separator;
+        ! otherwise (including hidden dotfiles like ".bashrc" or "dir/.hidden"),
+        ! return the full name component
+        if (last_dot > name_start) then
+            base_name = filename(name_start:last_dot-1)
+        else
+            base_name = filename(name_start:)
         end if
         
     end function get_base_name

--- a/test/test_get_base_name_dotfiles.f90
+++ b/test/test_get_base_name_dotfiles.f90
@@ -35,6 +35,17 @@ program test_get_base_name_dotfiles
         "xml_utility_helpers: dir/.hidden -> .hidden", &
         'Expected .hidden, got: ' // trim(result))
 
+    ! Hidden dotfile with extension: strip extension but keep leading dot
+    result = xml_utils_get_base_name('dir/.config.json')
+    call assert_test(trim(result) == '.config', &
+        "xml_utils_core: dir/.config.json -> .config", &
+        'Expected .config, got: ' // trim(result))
+
+    result = xml_helpers_get_base_name('dir/.config.json')
+    call assert_test(trim(result) == '.config', &
+        "xml_utility_helpers: dir/.config.json -> .config", &
+        'Expected .config, got: ' // trim(result))
+
     ! Regular names remain unchanged in behavior
     result = xml_utils_get_base_name('file.f90')
     call assert_test(trim(result) == 'file', &
@@ -59,4 +70,3 @@ program test_get_base_name_dotfiles
     call print_test_summary("GET_BASE_NAME DOTFILES", .true.)
 
 end program test_get_base_name_dotfiles
-

--- a/test/test_get_base_name_dotfiles.f90
+++ b/test/test_get_base_name_dotfiles.f90
@@ -1,0 +1,62 @@
+program test_get_base_name_dotfiles
+    !! Validate get_base_name behavior for hidden dotfiles and regular files
+
+    use iso_fortran_env, only: output_unit
+    use test_utils_core, only: assert_test, reset_test_counters, &
+         print_test_header, print_test_summary
+    use xml_utils_core, only: xml_utils_get_base_name => get_base_name
+    use xml_utility_helpers, only: xml_helpers_get_base_name => get_base_name
+    implicit none
+
+    character(len=:), allocatable :: result
+
+    call reset_test_counters()
+    call print_test_header("get_base_name dotfiles")
+
+    ! Hidden dotfile without extension: should remain intact
+    result = xml_utils_get_base_name('.bashrc')
+    call assert_test(trim(result) == '.bashrc', &
+        "xml_utils_core: .bashrc stays .bashrc", &
+        'Expected .bashrc, got: ' // trim(result))
+
+    result = xml_helpers_get_base_name('.bashrc')
+    call assert_test(trim(result) == '.bashrc', &
+        "xml_utility_helpers: .bashrc stays .bashrc", &
+        'Expected .bashrc, got: ' // trim(result))
+
+    ! Hidden file in directory
+    result = xml_utils_get_base_name('dir/.hidden')
+    call assert_test(trim(result) == '.hidden', &
+        "xml_utils_core: dir/.hidden -> .hidden", &
+        'Expected .hidden, got: ' // trim(result))
+
+    result = xml_helpers_get_base_name('dir/.hidden')
+    call assert_test(trim(result) == '.hidden', &
+        "xml_utility_helpers: dir/.hidden -> .hidden", &
+        'Expected .hidden, got: ' // trim(result))
+
+    ! Regular names remain unchanged in behavior
+    result = xml_utils_get_base_name('file.f90')
+    call assert_test(trim(result) == 'file', &
+        "xml_utils_core: file.f90 -> file", &
+        'Expected file, got: ' // trim(result))
+
+    result = xml_helpers_get_base_name('file.f90')
+    call assert_test(trim(result) == 'file', &
+        "xml_utility_helpers: file.f90 -> file", &
+        'Expected file, got: ' // trim(result))
+
+    result = xml_utils_get_base_name('path/to/file')
+    call assert_test(trim(result) == 'file', &
+        "xml_utils_core: path/to/file -> file", &
+        'Expected file, got: ' // trim(result))
+
+    result = xml_helpers_get_base_name('path/to/file')
+    call assert_test(trim(result) == 'file', &
+        "xml_utility_helpers: path/to/file -> file", &
+        'Expected file, got: ' // trim(result))
+
+    call print_test_summary("GET_BASE_NAME DOTFILES", .true.)
+
+end program test_get_base_name_dotfiles
+


### PR DESCRIPTION
Summary
- Fix get_base_name to preserve hidden dotfiles (e.g., .bashrc) without stripping to empty.

Scope
- Update get_base_name in two reporter utility modules.
- Add unit test for dotfiles and regular names.

Verification
- Ran: TEST_TIMEOUT=120 ./run_ci_tests.sh
- Result: 115 passed, 0 failed, 0 skipped.

Rationale
- Correct basename handling for hidden files; minimal, isolated change.
