### PR TITLE
fix: Remove non-ASCII emojis from runtime output to improve portability (fixes #1156)

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -149,8 +149,8 @@ program main
       end if
       print *, ""
       print *, "For configuration help:"
-      print *, "   • See example: cat fortcov.nml.example"
-      print *, "   • Documentation: https://github.com/lazy-fortran/fortcov"
+      print *, "   * See example: cat fortcov.nml.example"
+      print *, "   * Documentation: https://github.com/lazy-fortran/fortcov"
       ! EPIC 1 FIX: Map data availability errors to proper exit codes
       if (index(error_ctx%message, "Source path not found") > 0 .or. &
           index(error_ctx%message, "Coverage file not found") > 0) then

--- a/app/main.f90
+++ b/app/main.f90
@@ -79,7 +79,7 @@ program main
   if (config%zero_configuration_mode) then
     call enhance_zero_config_with_auto_discovery(config, enhancement_success, enhancement_error)
     if (.not. enhancement_success .and. .not. config%quiet) then
-      print *, "⚠️  Auto-discovery enhancement failed: " // trim(enhancement_error)
+      print *, "WARNING: Auto-discovery enhancement failed: " // trim(enhancement_error)
       print *, "   Continuing with basic zero-configuration mode"
     end if
   end if
@@ -127,7 +127,7 @@ program main
     inquire(file='.fortcov_execution_marker', exist=marker_exists)
     if (marker_exists) then
       if (.not. config%quiet) then
-        print *, "🛡️  Fork bomb prevention: fortcov execution disabled"
+        print *, "INFO: Fork bomb prevention: fortcov execution disabled"
         print *, "    (fortcov detected it's running within a test environment)"
       end if
       call exit_success_clean()


### PR DESCRIPTION
Summary
- Replace non-ASCII emojis in runtime messages with ASCII-only prefixes.

Scope
- app/main.f90 only; no behavioral change.

Verification
- Ran TEST_TIMEOUT=120 ./run_ci_tests.sh -> all tests passed locally (115/115).

Rationale
- Follows repo Cleanup & Style: avoid non-ASCII unless required; improves portability of logs in CI/terminals.
