### PR TITLE
fix: malformed Markdown fences in coverage workflow (fixes #1158)

### DIFF
--- a/doc/coverage_workflow.md
+++ b/doc/coverage_workflow.md
@@ -20,7 +20,6 @@ Requirements: `gfortran`, `gcov`, `fpm`.
 
 From the root of your FPM project:
 
-```bash
 ## Option 1: FortCov built-in
 
 ```bash
@@ -41,8 +40,6 @@ fortcov --gcov --output=coverage.md  # alias: --discover-and-gcov
 Notes:
 - If a script is not present in your project, copy it from this repository's
   `scripts/` directory or run it via a full path from the FortCov repository.
-```
-
 Outputs:
 - `coverage.md`: Markdown report (project summary and per-file stats)
 - `.gcov` files in the working directory


### PR DESCRIPTION
Summary
- Fix broken Markdown fences in `doc/coverage_workflow.md` causing rendering issues.

Scope
- Edit only `doc/coverage_workflow.md`; no code behavior changes.

Verification
- Rendered locally via inspection; no functional impact.
- Ran curated test suite to ensure no side effects:
  - ./run_ci_tests.sh (all tests passed)

Rationale
- The doc had nested ```bash blocks and a stray closing fence, making examples unclear.
