### PR TITLE
ci(e2e): build and use local fortcov binary in E2E validation

### DIFF
--- a/.github/workflows/e2e_pycobertura.yml
+++ b/.github/workflows/e2e_pycobertura.yml
@@ -35,7 +35,13 @@ jobs:
           # Generate Cobertura XML via gcovr
           gcovr -r . --xml-pretty -o coverage.xml || gcovr --xml-pretty -o coverage.xml
           # Generate FortCov markdown (single command workflow)
-          fortcov --output=coverage.md
+          fpm build --profile release
+          FORTCOV_BIN=$(find build -type f -path '*/app/fortcov' | head -n1)
+          if [ -z "${FORTCOV_BIN}" ]; then
+            echo "FortCov binary not found in build tree" >&2
+            exit 2
+          fi
+          "${FORTCOV_BIN}" --output=coverage.md
 
       - name: Compare totals (Cobertura vs FortCov)
         run: |


### PR DESCRIPTION
Summary
- Fix E2E workflow: ensure `fortcov` binary is built and invoked from the local build tree for coverage comparison.

Scope
- `.github/workflows/e2e_pycobertura.yml`: add `fpm build --profile release` and resolve the app binary path; use it for `--output=coverage.md`.

Verification
- PR checks should show E2E passing by producing both `coverage.xml` (gcovr) and `coverage.md` (FortCov) and comparing totals via `scripts/compare_coverage_metrics.py`.

Rationale
- Previous E2E failed with `fortcov: command not found` because the binary wasn't on PATH.
