### PR TITLE
fix: chore: remove TUI feature and codepaths (fixes #1162)

### DIFF
--- a/doc/user/usage-guide.md
+++ b/doc/user/usage-guide.md
@@ -64,13 +64,7 @@ fortcov --source=src *.gcov --minimum 80 --fail-under 90
 
 ## Advanced Analysis Features
 
-**Interactive TUI Mode:**
-```bash
-# Launch interactive terminal user interface
-fortcov --source=src *.gcov --tui
-```
-
-**Note**: Coverage diff analysis features are not yet implemented. Current implementation provides terminal coverage analysis and interactive TUI mode.
+Note: Coverage diff analysis features are not yet implemented. Current implementation provides terminal coverage analysis and file/JSON/HTML/XML reporting.
 
 ## Workflow Integration
 

--- a/src/config/args/config_detector_args.f90
+++ b/src/config/args/config_detector_args.f90
@@ -86,7 +86,6 @@ contains
                 flag_part == "--format" .or. flag_part == "-f" .or. &
                 flag_part == "--verbose" .or. flag_part == "-v" .or. &
                 flag_part == "--quiet" .or. flag_part == "-q" .or. &
-                flag_part == "--tui" .or. &
                 flag_part == "--diff" .or. &
                 flag_part == "--diff-threshold" .or. &
                 flag_part == "--include-unchanged" .or. &

--- a/src/config/core/config_defaults_core.f90
+++ b/src/config/core/config_defaults_core.f90
@@ -53,7 +53,6 @@ contains
         config%import_file = ""
         config%keep_gcov_files = .false.
         config%gcov_args = ""
-        config%tui_mode = .false.
         config%strict_mode = .false.
         config%zero_configuration_mode = .false.
         config%auto_discovery = .true.

--- a/src/config/core/config_types.f90
+++ b/src/config/core/config_types.f90
@@ -42,7 +42,6 @@ module config_types
         character(len=:), allocatable :: import_file
         logical :: keep_gcov_files
         character(len=:), allocatable :: gcov_args
-        logical :: tui_mode
         logical :: strict_mode
         logical :: zero_configuration_mode
         integer :: max_files  ! Maximum number of files to process

--- a/src/config/help/config_help_core.f90
+++ b/src/config/help/config_help_core.f90
@@ -67,7 +67,7 @@ contains
         print '(A)', "Advanced Options:"
         print '(A)', "  -t, --threads N           Reserved: parallel processing not implemented;"
         print '(A)', "                            this flag is currently ignored (single-threaded)"
-        print '(A)', "  --tui                     Launch terminal UI mode"
+        ! TUI removed
         print '(A)', "  --strict                  Enable strict mode (fail on warnings)"
         print '(A)', ""
         print '(A)', "Examples:"
@@ -90,7 +90,7 @@ contains
         print *, "  - Fortran compiler support"
         print *, "  - gcov file analysis (does not invoke gcov)"
         print *, "  - JSON/XML/HTML output formats"
-        print *, "  - Terminal User Interface (TUI)"
+        ! TUI removed
         print *, "  - Parallel processing: not implemented (threads flag ignored)"
         print *, ""
         print *, "Repository: https://github.com/lazy-fortran/fortcov"

--- a/src/config/parsers/config_parser_files.f90
+++ b/src/config/parsers/config_parser_files.f90
@@ -112,7 +112,7 @@ contains
             integer :: threads
             logical :: verbose
             logical :: quiet
-            logical :: tui_mode
+            ! TUI removed
             logical :: strict_mode
             logical :: enable_diff
             character(len=256) :: diff_baseline_file
@@ -133,14 +133,14 @@ contains
         ! SECURITY FIX Issue #963: gcov_executable removed - shell injection vulnerability
         real :: minimum_coverage, fail_under_threshold, diff_threshold
         integer :: threads, max_files
-        logical :: verbose, quiet, tui_mode, strict_mode, enable_diff, include_unchanged, keep_gcov_files
+        logical :: verbose, quiet, strict_mode, enable_diff, include_unchanged, keep_gcov_files
 
         ! Define the namelist
         namelist /fortcov_config/ &
             input_format, output_format, output_path, source_paths, &
             exclude_patterns, include_patterns, gcov_args, &
             minimum_coverage, fail_under_threshold, threads, &
-            verbose, quiet, tui_mode, strict_mode, enable_diff, &
+            verbose, quiet, strict_mode, enable_diff, &
             diff_baseline_file, include_unchanged, diff_threshold, &
             keep_gcov_files, max_files
 
@@ -164,7 +164,6 @@ contains
         threads = namelist_data%threads
         verbose = namelist_data%verbose
         quiet = namelist_data%quiet
-        tui_mode = namelist_data%tui_mode
         strict_mode = namelist_data%strict_mode
         enable_diff = namelist_data%enable_diff
         diff_baseline_file = namelist_data%diff_baseline_file
@@ -206,7 +205,6 @@ contains
         namelist_data%threads = threads
         namelist_data%verbose = verbose
         namelist_data%quiet = quiet
-        namelist_data%tui_mode = tui_mode
         namelist_data%strict_mode = strict_mode
         namelist_data%enable_diff = enable_diff
         namelist_data%diff_baseline_file = diff_baseline_file
@@ -237,7 +235,6 @@ contains
             namelist_data%threads = -1
             namelist_data%verbose = .false.
             namelist_data%quiet = .false.
-            namelist_data%tui_mode = .false.
             namelist_data%strict_mode = .false.
             namelist_data%enable_diff = .false.
             namelist_data%diff_baseline_file = ""
@@ -286,7 +283,6 @@ contains
             ! Transfer logical values
             config%verbose = namelist_data%verbose
             config%quiet = namelist_data%quiet
-            config%tui_mode = namelist_data%tui_mode
             config%strict_mode = namelist_data%strict_mode
             config%enable_diff = namelist_data%enable_diff
             config%include_unchanged = namelist_data%include_unchanged
@@ -335,8 +331,6 @@ contains
             config%verbose = (trim(adjustl(value)) == "true")
         case ("quiet")
             config%quiet = (trim(adjustl(value)) == "true")
-        case ("tui_mode")
-            config%tui_mode = (trim(adjustl(value)) == "true")
         case ("strict_mode")
             config%strict_mode = (trim(adjustl(value)) == "true")
         case ("keep_gcov_files")

--- a/src/config/parsers/config_parser_flags.f90
+++ b/src/config/parsers/config_parser_flags.f90
@@ -44,8 +44,8 @@ contains
          case ("--help", "-h", "--version", "-V", "--quiet", "-q", &
                "--verbose", "-v", "--validate", "--validate-architecture", "--diff", "--lcov", &
                "--auto-test", "--no-auto-test", "--auto-discovery", &
-               "--no-auto-discovery", "--zero-config", "--tui", "--fail-on-size-warnings", &
-               "--gcov", "--discover-and-gcov")
+              "--no-auto-discovery", "--zero-config", "--fail-on-size-warnings", &
+              "--gcov", "--discover-and-gcov")
              requires_value = .false.
         end select
     end function flag_requires_value
@@ -262,8 +262,6 @@ contains
             if (len_trim(value) > 0) then
                 config%config_file = value
             end if
-        case ("--tui")
-            config%tui_mode = .true.
         case ("--auto-discovery")
             config%auto_discovery = .true.
         case ("--no-auto-discovery")

--- a/src/config/validators/config_validation_core.f90
+++ b/src/config/validators/config_validation_core.f90
@@ -21,8 +21,8 @@ contains
 
         is_valid = .true.
 
-        ! Skip validation for help/version/TUI modes
-        if (config%show_help .or. config%show_version .or. config%tui_mode) then
+        ! Skip validation for help/version modes
+        if (config%show_help .or. config%show_version) then
             return
         end if
 
@@ -102,8 +102,8 @@ contains
         is_valid = .true.
         error_msg = ""
 
-        ! Skip validation for help/version/TUI modes
-        if (config%show_help .or. config%show_version .or. config%tui_mode) then
+        ! Skip validation for help/version modes
+        if (config%show_help .or. config%show_version) then
             return
         end if
 

--- a/src/core/reporting/report_generator_core.f90
+++ b/src/core/reporting/report_generator_core.f90
@@ -128,8 +128,7 @@ contains
             return
         end if
         
-        ! Start interactive TUI with configurable timeout
-        ! TUI removed: return success without interactive session
+        ! Interactive terminal UI removed; return success without session
         success = .true.
     end subroutine generator_generate_terminal
     

--- a/src/coverage/analysis/coverage_analysis_core.f90
+++ b/src/coverage/analysis/coverage_analysis_core.f90
@@ -29,8 +29,8 @@ module coverage_analysis_core
 contains
 
     function perform_coverage_analysis(config) result(exit_code)
-        !! Core coverage analysis implementation with interactive TUI support
-        type(config_t), intent(inout) :: config  ! Changed to inout for TUI mode
+        !! Core coverage analysis implementation
+        type(config_t), intent(inout) :: config
         integer :: exit_code
         
         ! Check for special modes first

--- a/src/coverage/analysis/coverage_analysis_core.f90
+++ b/src/coverage/analysis/coverage_analysis_core.f90
@@ -56,17 +56,11 @@ contains
     end function perform_coverage_analysis
 
     function check_special_modes(config) result(exit_code)
-        !! Check for special analysis modes with interactive configuration
-        type(config_t), intent(inout) :: config  ! Changed to inout for TUI mode
+        !! Check for special analysis modes
+        type(config_t), intent(inout) :: config
         integer :: exit_code
         
         exit_code = EXIT_SUCCESS
-        
-        ! TUI mode disabled: ignore to avoid interactive/blocking behavior
-        if (config%tui_mode) then
-            exit_code = EXIT_SUCCESS
-            return
-        end if
         
         ! Check for diff mode
         if (config%enable_diff) then

--- a/src/coverage/utils/coverage_integration_core.f90
+++ b/src/coverage/utils/coverage_integration_core.f90
@@ -99,7 +99,7 @@ contains
         logical :: workflows_valid
         
         logical :: basic_analysis_workflow, diff_analysis_workflow
-        logical :: json_import_workflow, tui_workflow
+        logical :: json_import_workflow
         
         workflows_valid = .true.
         
@@ -124,12 +124,7 @@ contains
             workflows_valid = .false.
         end if
         
-        ! Test TUI workflow
-        tui_workflow = test_tui_workflow()
-        if (.not. tui_workflow) then
-            print *, "❌ TUI workflow failed"
-            workflows_valid = .false.
-        end if
+        ! TUI workflow removed
         
     end function test_end_to_end_workflows
     
@@ -273,13 +268,7 @@ contains
         
     end function test_json_import_workflow
     
-    function test_tui_workflow() result(passed)
-        logical :: passed
-        
-        ! Test TUI workflow
-        passed = .true.
-        
-    end function test_tui_workflow
+    ! TUI workflow test removed
     
     function test_orchestrator_analysis_compatibility() result(compatible)
         logical :: compatible

--- a/src/coverage/utils/coverage_orchestrator_core.f90
+++ b/src/coverage/utils/coverage_orchestrator_core.f90
@@ -29,9 +29,9 @@ module coverage_orchestrator_core
 contains
     
     function analyze_coverage(config) result(exit_code)
-        !! Main coverage analysis orchestration with interactive TUI support
+        !! Main coverage analysis orchestration
         !! Delegates to specialized analysis module while maintaining interface stability
-        type(config_t), intent(inout) :: config  ! Changed to inout for TUI mode
+        type(config_t), intent(inout) :: config
         integer :: exit_code
         
         class(orchestrator_interface_t), allocatable :: orchestrator
@@ -85,9 +85,9 @@ contains
     end function check_exclude_patterns
     
     function analyze_coverage_safe(config, error_ctx) result(exit_code)
-        !! Safe coverage analysis orchestration with interactive TUI support
+        !! Safe coverage analysis orchestration
         !! Delegates to specialized analysis module with error handling
-        type(config_t), intent(inout) :: config  ! Changed to inout for TUI mode
+        type(config_t), intent(inout) :: config
         type(error_context_t), intent(out) :: error_ctx
         integer :: exit_code
         

--- a/src/coverage/workflows/coverage_workflow_core.f90
+++ b/src/coverage/workflows/coverage_workflow_core.f90
@@ -205,37 +205,6 @@ contains
         
     end function orchestrate_diff_analysis
 
-    function orchestrate_tui_launch(config) result(exit_code)
-        !! Orchestrate TUI mode launch
-        !! 
-        !! Simple orchestration for TUI mode launch with proper
-        !! error handling and user feedback.
-        type(config_t), intent(in) :: config
-        integer :: exit_code
-        
-        logical :: tui_success
-        
-        exit_code = EXIT_SUCCESS
-        
-        if (.not. config%quiet) then
-            print *, "🔄 Orchestrating TUI mode launch..."
-        end if
-        
-        ! Launch TUI interface (placeholder implementation)
-        tui_success = .true.  ! Placeholder for actual TUI launch
-        
-        if (.not. tui_success) then
-            if (.not. config%quiet) then
-                print *, "❌ TUI launch failed"
-            end if
-            exit_code = EXIT_FAILURE
-            return
-        end if
-        
-        if (.not. config%quiet) then
-            print *, "✅ TUI mode launched successfully"
-        end if
-        
-    end function orchestrate_tui_launch
+    ! TUI orchestration removed
 
 end module coverage_workflow_core

--- a/src/coverage/workflows/coverage_workflows.f90
+++ b/src/coverage/workflows/coverage_workflows.f90
@@ -7,8 +7,7 @@ module coverage_workflows
     use coverage_workflows_discovery, only: discover_coverage_files, &
                                             filter_coverage_files_by_patterns, &
                                             evaluate_exclude_patterns
-    use coverage_workflows_analysis, only: perform_coverage_diff_analysis, &
-                                           launch_coverage_tui_mode
+    use coverage_workflows_analysis, only: perform_coverage_diff_analysis
     use coverage_test_executor, only: execute_auto_test_workflow
     implicit none
     private
@@ -17,7 +16,6 @@ module coverage_workflows
     public :: discover_coverage_files
     public :: evaluate_exclude_patterns
     public :: perform_coverage_diff_analysis
-    public :: launch_coverage_tui_mode
     public :: filter_coverage_files_by_patterns
     public :: execute_auto_test_workflow
 end module coverage_workflows

--- a/src/coverage/workflows/coverage_workflows_analysis.f90
+++ b/src/coverage/workflows/coverage_workflows_analysis.f90
@@ -1,8 +1,8 @@
 module coverage_workflows_analysis
-    !! Coverage analysis workflows including diff analysis and TUI operations
+    !! Coverage analysis workflows including diff analysis
     !!
-    !! Provides high-level analysis workflows for coverage comparison,
-    !! terminal user interface launching, and analysis result reporting.
+    !! Provides high-level analysis workflows for coverage comparison
+    !! and analysis result reporting.
     
     use constants_core
     use config_core

--- a/src/coverage/workflows/coverage_workflows_analysis.f90
+++ b/src/coverage/workflows/coverage_workflows_analysis.f90
@@ -12,7 +12,6 @@ module coverage_workflows_analysis
     private
     
     public :: perform_coverage_diff_analysis
-    public :: launch_coverage_tui_mode
     
 contains
 
@@ -68,30 +67,8 @@ contains
         
     end function perform_coverage_diff_analysis
     
-    function launch_coverage_tui_mode(config) result(exit_code)
-        !! TUI mode launch workflow implementation with interactive configuration
-        !! Extracted from original launch_tui_mode function
-        type(config_t), intent(inout) :: config  ! Changed to inout for interactive config
-        integer :: exit_code
-        
-        logical :: tui_success
-        
-        exit_code = EXIT_SUCCESS
-        
-        ! TUI disabled: treat as no-op success to keep CLI stable
-        tui_success = .true.
-        
-        if (.not. tui_success) then
-            if (.not. config%quiet) then
-                print *, "❌ TUI launch failed"
-            end if
-            exit_code = EXIT_FAILURE
-        end if
-        
-    end function launch_coverage_tui_mode
-    
     ! Internal helper routines
-    
+
     subroutine output_coverage_diff_summary(diff_result, config)
         !! Outputs coverage diff analysis summary
         type(coverage_diff_t), intent(in) :: diff_result
@@ -117,11 +94,6 @@ contains
         
     end subroutine output_coverage_diff_summary
     
-    subroutine start_tui_interface(config, success)
-        !! Stubbed out: TUI removed
-        type(config_t), intent(inout) :: config
-        logical, intent(out) :: success
-        success = .true.
-    end subroutine start_tui_interface
+    ! TUI interface removed
 
 end module coverage_workflows_analysis

--- a/test/test_cli_argument_parsing_issue_228.f90
+++ b/test/test_cli_argument_parsing_issue_228.f90
@@ -48,7 +48,7 @@ program test_cli_argument_parsing_issue_228
     call test_missing_files_silently_ignored(test_counter)
     
     ! Test behavioral verification for all major CLI flags
-    call test_tui_mode_behavioral_verification(test_counter)
+    ! TUI mode removed
     call test_diff_mode_behavioral_verification(test_counter)
     call test_strict_mode_behavioral_verification(test_counter)
     call test_threshold_behavioral_verification(test_counter)
@@ -137,13 +137,7 @@ contains
         print *, "  ✅ PASS: Missing files properly detected"
     end subroutine test_missing_files_silently_ignored
     
-    subroutine test_tui_mode_behavioral_verification(counter)
-        use test_framework_utilities, only: test_counter_t, increment_pass
-        type(test_counter_t), intent(inout) :: counter
-        print *, "Test: TUI mode behavioral verification"
-        call increment_pass(counter)
-        print *, "  ✅ PASS: TUI mode behavior verified"
-    end subroutine test_tui_mode_behavioral_verification
+    ! TUI mode behavioral verification removed
     
     subroutine test_diff_mode_behavioral_verification(counter)
         use test_framework_utilities, only: test_counter_t, increment_pass

--- a/test/test_coverage_workflows_decomposition.f90
+++ b/test/test_coverage_workflows_decomposition.f90
@@ -21,7 +21,7 @@ program test_coverage_workflows_decomposition
     call test_evaluate_exclude_patterns()
     call test_filter_coverage_files_by_patterns()
     call test_perform_coverage_diff_analysis()
-    call test_launch_coverage_tui_mode()
+    ! TUI mode removed
     ! Removed auto-test workflow invocation to avoid recursive fpm test
 
     write(output_unit, *)
@@ -125,19 +125,7 @@ contains
         call assert_not_equals_int(exit_code, -999, 'Threshold handling works')
     end subroutine test_perform_coverage_diff_analysis
 
-    subroutine test_launch_coverage_tui_mode()
-        !! Test TUI mode launch workflow
-        type(config_t) :: config
-        integer :: exit_code
-        
-        write(output_unit, '(A)') 'Test 5: TUI mode launch'
-        
-        call initialize_default_config(config)
-        config%quiet = .true.  ! Suppress output during testing
-        
-        exit_code = launch_coverage_tui_mode(config)
-        call assert_equals_int(exit_code, EXIT_SUCCESS, 'TUI mode launches')
-    end subroutine test_launch_coverage_tui_mode
+    ! TUI test removed
 
     ! Test 6 removed: auto-test workflow execution would trigger nested fpm test
 


### PR DESCRIPTION
Summary
- Remove TUI flag, config field, help/version mentions, and dead code.

Scope
- Remove `tui_mode` from config/types, parsers, validators.
- Drop `--tui` flag handling and help text.
- Remove TUI workflows and orchestration stubs and references.
- Update tests to stop referencing TUI.

Verification
- Ran `fpm test` locally (120s timeout): all tests passed.
- Help/version output no longer mentions TUI and remains functional.

Rationale
- Aligns with project scope; reduces complexity and unused surface area.
