### PR TITLE
fix: docs: tighten README to actual scope and supported features (fixes #1179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Outputs by default:
 ```bash
 set -e
 # Single-command CI-friendly execution (auto FPM + gcov + report)
-fortcov --fail-under 80 --quiet
+fortcov --gcov --fail-under 80 --quiet
 ```
 
 Exit codes: `0` success, `2` threshold not met, `3` no coverage data.


### PR DESCRIPTION
Summary
- Tighten README to match actual behavior: defaults analyze existing .gcov; auto-discovery requires --gcov.

Scope
- Update README only; no code changes.

Verification
- fpm test passes locally; help output aligns with README changes.

Rationale
- Removes inaccurate claims; keeps examples concise and copy-pasteable.
