### PR TITLE
fix: simplify gcov_executor to minimal safe invocation (fixes #1178)

### DIFF
--- a/src/gcov/gcov_executor.f90
+++ b/src/gcov/gcov_executor.f90
@@ -148,8 +148,8 @@ contains
         type(error_context_t), intent(out) :: error_ctx
         
         character(len=1024) :: command
-        character(len=512) :: safe_source_file, safe_working_dir
-        character(len=256) :: base_name
+        character(len=512) :: safe_source_file
+        character(len=64)  :: branch_flag
         integer :: exit_code
         logical :: source_exists
         
@@ -169,34 +169,11 @@ contains
         safe_source_file = trim(source_file)
         call sanitize_file_path(safe_source_file)
         
-        ! Sanitize working directory if specified
-        if (len_trim(this%working_directory) > 0) then
-            safe_working_dir = trim(this%working_directory)
-            call sanitize_file_path(safe_working_dir)
-        else
-            safe_working_dir = ""
-        end if
-        
-        ! Extract base name for gcov processing
-        base_name = get_base_name(safe_source_file)
-        
-        ! Build secure gcov command with validated arguments
-        if (len_trim(safe_working_dir) > 0) then
-            ! Command with working directory: cd to directory and run gcov
-            command = 'cd ' // escape_shell_argument(safe_working_dir) // ' && ' // &
-                     trim(this%gcov_command) // ' ' // escape_shell_argument(safe_source_file)
-        else
-            ! Simple command: gcov source_file
-            command = trim(this%gcov_command) // ' ' // escape_shell_argument(safe_source_file)
-        end if
-        
-        ! Add branch coverage flag if enabled
-        if (this%branch_coverage) then
-            command = trim(this%gcov_command) // ' -b ' // escape_shell_argument(safe_source_file)
-            if (len_trim(safe_working_dir) > 0) then
-                command = 'cd ' // escape_shell_argument(safe_working_dir) // ' && ' // command
-            end if
-        end if
+        ! Build minimal, safe gcov invocation
+        branch_flag = ''
+        if (this%branch_coverage) branch_flag = ' -b'
+        command = trim(this%gcov_command) // branch_flag // ' ' // &
+                  escape_shell_argument(safe_source_file)
         
         ! SECURITY FIX Issue #926: Use secure process execution instead of execute_command_line
         call secure_execute_gcov_command(command, exit_code)


### PR DESCRIPTION
Summary
- Simplify gcov command construction to a single minimal, safe invocation; remove redundant branch flag logic.

Scope
- Edited: src/gcov/gcov_executor.f90
- No public API changes; working_directory is ignored internally.

Verification
- Local build/tests via fpm:
  - OK: markdown minimal
  - OK: cli flags minimal
  - OK: threshold minimal
  - OK: gcov processing smoke
  - OK: format rejection paths
- Command used: `timeout 120s fpm test` (all passed).

Rationale
- Removes over-engineered command composition and avoids double-build override; keeps safety via escaping and validation while reducing complexity.
