### PR TITLE
fix: e2e(pycobertura): failing after test-env guard; unblock PR #1210 (fixes #1211)

### DIFF
--- a/.github/workflows/e2e_pycobertura.yml
+++ b/.github/workflows/e2e_pycobertura.yml
@@ -10,6 +10,8 @@ jobs:
     name: Compare FortCov vs Cobertura (gcovr)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      FORTCOV_ALLOW_AUTOTEST: "1"
 
     steps:
       - name: Checkout repository

--- a/doc/coverage_workflow.md
+++ b/doc/coverage_workflow.md
@@ -71,3 +71,8 @@ By default, `fortcov` analyzes existing `.gcov` files and does not invoke
 `gcov` or run your tests. Use the built-in bridge `--gcov` (alias:
 `--discover-and-gcov`) to auto-discover FPM/CMake build directories, run under
 coverage, generate `.gcov`, and then analyze them.
+
+Test-environment guard: When `fortcov` detects it is running under a test
+harness (e.g., `fpm test`), it skips auto-running tests to avoid recursion.
+In controlled CI jobs where this is desired, set the environment variable
+`FORTCOV_ALLOW_AUTOTEST=1` to explicitly allow the auto-test bridge.

--- a/fpm.toml
+++ b/fpm.toml
@@ -26,3 +26,8 @@ main = "main.f90"
 name = "cli_flags_rejection_minimal"
 source-dir = "test"
 main = "test_cli_flags_rejection_minimal.f90"
+
+[[test]]
+name = "test_env_guard_override"
+source-dir = "test"
+main = "test_test_env_guard_override.f90"

--- a/src/utils/runtime/test_env_guard.f90
+++ b/src/utils/runtime/test_env_guard.f90
@@ -2,7 +2,6 @@ module test_env_guard
     !! Runtime test-environment detection to prevent recursive execution
     !! Used to avoid spawning external test runners (e.g., fpm test) when
     !! fortcov itself is being run under a test harness.
-    use iso_fortran_env, only: error_unit
     implicit none
     private
 

--- a/src/utils/runtime/test_env_guard.f90
+++ b/src/utils/runtime/test_env_guard.f90
@@ -18,6 +18,13 @@ contains
 
         is_test_env = .false.
 
+        ! Allow explicit override to enable auto-test/bridge in controlled environments
+        call get_environment_variable('FORTCOV_ALLOW_AUTOTEST', env_value, status=status)
+        if (status == 0 .and. len_trim(env_value) > 0) then
+            is_test_env = .false.
+            return
+        end if
+
         call get_environment_variable('FPM_TEST', env_value, status=status)
         if (status == 0 .and. len_trim(env_value) > 0) then
             is_test_env = .true.
@@ -50,4 +57,3 @@ contains
     end function running_under_test_env
 
 end module test_env_guard
-

--- a/test/test_test_env_guard_override.f90
+++ b/test/test_test_env_guard_override.f90
@@ -1,0 +1,42 @@
+program test_test_env_guard_override
+    use iso_fortran_env, only: error_unit
+    use iso_c_binding, only: c_int, c_char
+    use test_env_guard, only: running_under_test_env
+    implicit none
+
+    interface
+        function c_setenv(name, value, overwrite) bind(C, name="setenv") result(ret)
+            import :: c_int, c_char
+            character(kind=c_char), dimension(*) :: name
+            character(kind=c_char), dimension(*) :: value
+            integer(c_int), value :: overwrite
+            integer(c_int) :: ret
+        end function c_setenv
+    end interface
+
+    logical :: is_test
+
+    if (c_setenv('FORTCOV_TEST_MODE' // char(0), '1' // char(0), 1_c_int) /= 0_c_int) then
+        write(error_unit, '(A)') 'Failed to set FORTCOV_TEST_MODE'
+        stop 1
+    end if
+
+    is_test = running_under_test_env()
+    if (.not. is_test) then
+        write(error_unit, '(A)') 'Expected test environment detection to be TRUE'
+        stop 2
+    end if
+
+    if (c_setenv('FORTCOV_ALLOW_AUTOTEST' // char(0), '1' // char(0), 1_c_int) /= 0_c_int) then
+        write(error_unit, '(A)') 'Failed to set FORTCOV_ALLOW_AUTOTEST'
+        stop 3
+    end if
+
+    is_test = running_under_test_env()
+    if (is_test) then
+        write(error_unit, '(A)') 'Override did not bypass test environment guard'
+        stop 4
+    end if
+
+    print *, 'OK: test_env_guard override bypasses test detection when enabled'
+end program test_test_env_guard_override


### PR DESCRIPTION
Summary
- Add CI override `FORTCOV_ALLOW_AUTOTEST` to bypass test-env guard when safe.
- Set job env in e2e_pycobertura to keep auto paths available in CI.

Verification
- Pytest: `pytest -q --maxfail=1 --disable-warnings`
  Output: `3 passed in 0.05s`
- fpm tests: `/usr/bin/timeout 120s fpm test`
  Excerpts:
  - `OK: cli flags rejection minimal`
  - `OK: test_env_guard override bypasses test detection when enabled`
- Files:
  - src/utils/runtime/test_env_guard.f90
  - test/test_test_env_guard_override.f90
  - .github/workflows/e2e_pycobertura.yml
  - fpm.toml

Rationale
- E2E job failed after adding test-environment guard which skips auto-test/bridge.
- Introducing a CI-only opt-in env keeps guards intact for tests while unblocking E2E.
