### PR TITLE
fix: return exit code 3 when no coverage files found (fixes #1220)

### DIFF
--- a/src/coverage/analysis/coverage_analysis_core.f90
+++ b/src/coverage/analysis/coverage_analysis_core.f90
@@ -152,23 +152,15 @@ contains
         !! Handle case when no coverage files are found
         type(config_t), intent(in) :: config
         integer :: exit_code
-        character(len=256) :: test_env
-        integer :: env_status
-        
-        ! Check if we're in test mode
-        call get_environment_variable('FORTCOV_TEST_MODE', test_env, status=env_status)
-        
+
         if (.not. config%quiet) then
             print *, "No coverage files found for analysis."
         end if
-        
-        ! In test mode OR zero-configuration mode, return NO_COVERAGE_DATA instead of FAILURE
-        if (env_status == 0 .or. config%zero_configuration_mode) then
-            exit_code = EXIT_NO_COVERAGE_DATA
-        else
-            exit_code = EXIT_FAILURE
-        end if
-        
+
+        ! Always return EXIT_NO_COVERAGE_DATA (3) when no coverage files found
+        ! This allows CI scripts to distinguish between no coverage data and errors
+        exit_code = EXIT_NO_COVERAGE_DATA
+
     end function handle_missing_coverage_files
 
     function perform_safe_coverage_analysis(config, error_ctx) result(exit_code)

--- a/src/coverage/workflows/coverage_workflow_core.f90
+++ b/src/coverage/workflows/coverage_workflow_core.f90
@@ -56,9 +56,9 @@ contains
         ! Validate discovered files
         if (.not. allocated(coverage_files) .or. size(coverage_files) == 0) then
             if (.not. config%quiet) then
-                print *, "❌ No coverage files discovered"
+                print *, "No coverage files discovered"
             end if
-            exit_code = EXIT_FAILURE
+            exit_code = EXIT_NO_COVERAGE_DATA
             return
         end if
         


### PR DESCRIPTION
## Summary

- Fixes exit code behavior when no coverage files are found
- Previously returned exit code 1 (general failure), now correctly returns exit code 3 (no coverage data)
- Allows CI scripts to distinguish between processing errors and missing coverage data scenarios

## Test plan

Verified by running fortcov in an empty directory:

```bash
mkdir -p /tmp/fortcov_empty_test && cd /tmp/fortcov_empty_test
rm -f *.gcov
fortcov
echo "Exit code: $?"
# Output: Exit code: 3
```

All existing tests pass:
```
fpm test
# OK: cli flags rejection minimal
# OK: test_env_guard override bypasses test detection when enabled
```