### PR TITLE
fix: clarify version output about gcov invocation (fixes #1221)

### DIFF
--- a/src/config/help/config_help_core.f90
+++ b/src/config/help/config_help_core.f90
@@ -58,7 +58,7 @@ contains
         print *, ""
         print *, "Built with:"
         print *, "  - Fortran compiler support"
-        print *, "  - gcov file analysis (does not invoke gcov)"
+        print *, "  - gcov file analysis (use --gcov to invoke gcov)"
         print *, "  - Markdown output format"
         ! TUI removed
         print *, "  - Parallel processing: not implemented (threads flag ignored)"


### PR DESCRIPTION
## Summary

- Fixed version output that said "does not invoke gcov" which contradicted the help text
- Changed to "use --gcov to invoke gcov" to clarify that gcov invocation is available via the --gcov flag

## Problem

The `--version` output said:
```
  - gcov file analysis (does not invoke gcov)
```

But `--help` said:
```
--gcov  Auto-discover builds and run gcov before analysis
```

This was confusing because the version implied gcov is never invoked, while help showed it can be invoked with `--gcov`.

## Solution

Updated version text to:
```
  - gcov file analysis (use --gcov to invoke gcov)
```

This clarifies that:
1. By default, fortcov analyzes existing .gcov files
2. Users can use `--gcov` to have fortcov invoke gcov

## Verification

```bash
$ fpm run -- --version
 fortcov version 0.4.0
 Fortran Coverage Analysis Tool
 
 Built with:
   - Fortran compiler support
   - gcov file analysis (use --gcov to invoke gcov)
   - Markdown output format
   - Parallel processing: not implemented (threads flag ignored)
 
 Repository: https://github.com/lazy-fortran/fortcov
 License: MIT

$ fpm test
# All tests pass (5 passed, 0 failed)
```

## Test plan

- [x] Verify version output is consistent with help text
- [x] All existing tests pass