### PR TITLE
fix: wrap lines exceeding 88-column limit (fixes #1227)

### DIFF
--- a/src/core/system/system_protection.f90
+++ b/src/core/system/system_protection.f90
@@ -1,5 +1,6 @@
 module system_protection
-    use error_handling_core, only: error_context_t, ERROR_INVALID_PATH, safe_write_message
+    use error_handling_core, only: error_context_t, ERROR_INVALID_PATH, &
+        safe_write_message
     use path_string_utils, only: starts_with_ignore_case
     implicit none
     private
@@ -37,8 +38,9 @@ contains
             '/proc/', '/sys/ ', '/dev/ ' &
         ]
         
-        ! SECURITY BALANCE IMPROVEMENT: Allow legitimate /tmp output while preserving security
-        ! /tmp is standard Unix temporary directory - legitimate for output file creation
+        ! SECURITY BALANCE IMPROVEMENT: Allow legitimate /tmp output while
+        ! preserving security. /tmp is standard Unix temporary directory -
+        ! legitimate for output file creation
         ! Check for /tmp/ prefix AND /tmp exactly (directory itself)
         if (starts_with_ignore_case(path, '/tmp/') .or. trim(path) == '/tmp') then
             return


### PR DESCRIPTION
## Summary

- Wrap lines in `src/core/system/system_protection.f90` to comply with 88-column limit
- Line 2: use statement (90 -> 62+28 chars with continuation)
- Lines 40-41: comments (94 and 89 chars -> rewrapped to three shorter lines)

## Verification

```
$ awk '{if(length($0) > 88) print NR": "length($0)" chars"}' src/core/system/system_protection.f90
(no output - all lines within limit)
```

```
$ fpm test
Results: 5 passed, 0 failed
```