### PR TITLE
fix: wrap long lines and remove stale comments (fixes #1231)

### DIFF
--- a/test/test_logging_glitches_1123.f90
+++ b/test/test_logging_glitches_1123.f90
@@ -17,7 +17,8 @@ contains
 
     subroutine test_discovery_message_format()
         character(len=256) :: buf
-        character(len=*), parameter :: expected = 'FortCov: Discovery returned 249 files'
+        character(len=*), parameter :: expected = &
+            'FortCov: Discovery returned 249 files'
 
         tests = tests + 1
 
@@ -26,9 +27,11 @@ contains
 
         if (index(buf, new_line('a')) == 0 .and. trim(buf) == expected) then
             passed = passed + 1
-            write(output_unit,'(A)') '  [PASS] Discovery message formatted on a single line'
+            write(output_unit,'(A)') &
+                '  [PASS] Discovery message formatted on a single line'
         else
-            write(output_unit,'(A)') '  [FAIL] Discovery message formatting contains newline or mismatch'
+            write(output_unit,'(A)') &
+                '  [FAIL] Discovery message formatting has newline/mismatch'
             write(output_unit,'(A,A)') '    Expected: ', expected
             write(output_unit,'(A,A)') '    Actual:   ', trim(buf)
         end if

--- a/test/test_memory_allocation_bug_issue_243.f90
+++ b/test/test_memory_allocation_bug_issue_243.f90
@@ -2,11 +2,6 @@ program test_memory_allocation_bug_issue_243
     !! Memory allocation safety test for Issue #243
     !! Tests memory safety without external dependencies
     !! CI-optimized version for reliable test execution
-    !! 
-    !! Note: The comprehensive memory tests are in separate test programs:
-    !! - test_memory_allocation_core: Core allocation patterns
-    !! - test_memory_error_paths: Error handling paths
-    !! These run independently via FPM's test system
     
     use iso_fortran_env, only: error_unit, int64
     implicit none
@@ -28,16 +23,12 @@ program test_memory_allocation_bug_issue_243
     print *, ""
     print *, "============================================================="
     if (all_tests_passed) then
-        print *, "✅ MEMORY ALLOCATION SAFETY TESTS PASSED"
+        print *, "MEMORY ALLOCATION SAFETY TESTS PASSED"
         print *, "Issue #243: Basic memory safety verified"
-        print *, ""
-        print *, "Note: Run full test suite for comprehensive coverage:"
-        print *, "  - test_memory_allocation_core (core patterns)"
-        print *, "  - test_memory_error_paths (error handling)"
         print *, "============================================================="
         stop 0
     else
-        write(error_unit, *) "❌ MEMORY SAFETY TESTS FAILED"
+        write(error_unit, *) "MEMORY SAFETY TESTS FAILED"
         print *, "============================================================="
         stop 1
     end if
@@ -62,7 +53,7 @@ contains
         
         ! Verify allocation
         if (.not. allocated(test_array)) then
-            print *, "  ❌ FAIL: Array not allocated after allocate"
+            print *, "  FAIL: Array not allocated after allocate"
             all_tests_passed = .false.
             return
         end if
@@ -70,7 +61,7 @@ contains
         ! Clean up
         deallocate(test_array)
         
-        print *, "  ✅ PASS: Basic allocation safety verified"
+        print *, "  PASS: Basic allocation safety verified"
         
     end subroutine test_basic_allocation_safety
     
@@ -99,12 +90,12 @@ contains
         
         ! Verify deallocation
         if (allocated(int_array)) then
-            print *, "  ❌ FAIL: Array still allocated after deallocate"
+            print *, "  FAIL: Array still allocated after deallocate"
             all_tests_passed = .false.
             return
         end if
         
-        print *, "  ✅ PASS: Deallocation safety verified"
+        print *, "  PASS: Deallocation safety verified"
         
     end subroutine test_deallocation_safety
     
@@ -147,7 +138,7 @@ contains
         ! Clean up
         deallocate(string_array)
         
-        print *, "  ✅ PASS: Reallocation patterns verified"
+        print *, "  PASS: Reallocation patterns verified"
         
     end subroutine test_reallocation_patterns
     

--- a/test/test_string_concatenation_fix_364.f90
+++ b/test/test_string_concatenation_fix_364.f90
@@ -38,8 +38,9 @@ contains
         
         ! This is the fix - direct concatenation instead of formatted write
         pattern_result = trim(test_build_dir) // '/' // GCOV_PATTERN
-        
-        call assert_equals(trim(pattern_result), expected, 'Pattern concatenated correctly')
+
+        call assert_equals(trim(pattern_result), expected, &
+                           'Pattern concatenated correctly')
     end subroutine test_gcov_pattern_concatenation
 
     subroutine test_gcov_pattern_edge_cases()
@@ -55,16 +56,18 @@ contains
         
         ! Test with build dir ending in slash
         pattern_result = trim('/build/') // '/' // GCOV_PATTERN
-        call assert_equals(trim(pattern_result), '/build//*.gcov', 'Trailing slash handled')
+        call assert_equals(trim(pattern_result), '/build//*.gcov', &
+                           'Trailing slash handled')
         
         ! Test with very long path (should not exceed buffer)
         block
             character(len=200) :: long_path
             long_path = repeat('x', 200)
             
-            ! This should work without "End of record" error
+            ! This should work without End of record error
             pattern_result = trim(long_path) // '/' // GCOV_PATTERN
-            call assert_true(len_trim(pattern_result) > 0, 'Long path concatenation works')
+            call assert_true(len_trim(pattern_result) > 0, &
+                             'Long path concatenation works')
         end block
     end subroutine test_gcov_pattern_edge_cases
 
@@ -72,28 +75,28 @@ contains
     
     subroutine assert_equals(actual, expected, description)
         character(len=*), intent(in) :: actual, expected, description
-        
+
         test_count = test_count + 1
         if (actual == expected) then
             passed_count = passed_count + 1
-            write(output_unit, '(A,A)') '  ✓ ', description
+            write(output_unit, '(A,A)') '  PASS: ', description
         else
-            write(output_unit, '(A,A)') '  ✗ ', description
+            write(output_unit, '(A,A)') '  FAIL: ', description
             write(output_unit, '(A,A)') '    Expected: ', expected
             write(output_unit, '(A,A)') '    Actual:   ', actual
         end if
     end subroutine assert_equals
-    
+
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition
         character(len=*), intent(in) :: description
-        
+
         test_count = test_count + 1
         if (condition) then
             passed_count = passed_count + 1
-            write(output_unit, '(A,A)') '  ✓ ', description
+            write(output_unit, '(A,A)') '  PASS: ', description
         else
-            write(output_unit, '(A,A)') '  ✗ ', description
+            write(output_unit, '(A,A)') '  FAIL: ', description
         end if
     end subroutine assert_true
 


### PR DESCRIPTION
## Summary

- Wrap lines exceeding 88-column limit in `test_logging_glitches_1123.f90` (lines 20, 29, 31)
- Wrap lines exceeding 88-column limit in `test_string_concatenation_fix_364.f90` (lines 42, 58, 67)
- Remove stale comments referencing non-existent tests (`test_memory_allocation_core`, `test_memory_error_paths`) in `test_memory_allocation_bug_issue_243.f90`
- Remove emojis from test output messages per project style guidelines

## Verification

```
$ fpm test 2>&1 | tail -20
  [PASS] Discovery message formatted on a single line
Test Results: 1 / 1 passed
Testing string concatenation fix for issue #364...

Test: GCOV pattern string concatenation
  PASS: Pattern concatenated correctly
Test: GCOV pattern edge cases
  PASS: Empty dir handled
  PASS: Trailing slash handled
  PASS: Long path concatenation works

Test Results: 4 / 4 tests passed
...
 MEMORY ALLOCATION SAFETY TESTS PASSED
 Issue #243: Basic memory safety verified
 =============================================================
```

All 3 test programs pass (6/6 assertions).