### PR TITLE
fix: enable auto-discovery in --gcov mode (fixes #1235)

### DIFF
--- a/src/config/args/config_positional_args.f90
+++ b/src/config/args/config_positional_args.f90
@@ -34,7 +34,10 @@ contains
         success = .true.
         error_message = ""
 
-        ! Allocate coverage files array
+        ! Only process if there are positional arguments
+        if (positional_count == 0) return
+
+        ! Allocate coverage files array only when needed
         if (allocated(config%coverage_files)) deallocate(config%coverage_files)
         allocate(character(len=0) :: config%coverage_files(0))
 
@@ -67,6 +70,11 @@ contains
                 ! Note: executable paths are silently ignored (no warning needed)
             end if
         end do
+
+        ! Deallocate if no coverage files were found - allows auto-discovery
+        if (allocated(config%coverage_files) .and. size(config%coverage_files) == 0) then
+            deallocate(config%coverage_files)
+        end if
 
     end subroutine process_positional_arguments
 

--- a/src/coverage/processors/coverage_processor_gcov.f90
+++ b/src/coverage/processors/coverage_processor_gcov.f90
@@ -21,23 +21,23 @@ contains
         !! Implements "sane default mode" - auto-discovers coverage files and runs gcov
         type(config_t), intent(in) :: config
         character(len=:), allocatable, intent(out) :: files(:)
-        
+
         character(len=:), allocatable :: search_paths(:)
         character(len=:), allocatable :: found_files(:)
         character(len=:), allocatable :: generated_files(:)
-        
+
         ! Determine search paths based on configuration
         call determine_gcov_search_paths(config, search_paths, found_files)
-        
+
         ! Search for existing .gcov files if needed
         call search_existing_gcov_files(search_paths, found_files)
-        
+
         ! Generate gcov files if none found and in auto-discovery mode
         call attempt_gcov_generation(config, found_files, generated_files)
-        
+
         ! Set final result
         call finalize_gcov_file_result(found_files, generated_files, files)
-        
+
     end subroutine discover_gcov_files
     
     subroutine auto_generate_gcov_files(config, generated_files)
@@ -45,16 +45,16 @@ contains
         !! Implements the core "sane default mode" functionality for Issue #196
         type(config_t), intent(in) :: config
         character(len=:), allocatable, intent(out) :: generated_files(:)
-        
+
         character(len=:), allocatable :: build_dirs(:)
         character(len=:), allocatable :: all_gcov_files(:)
         character(len=:), allocatable :: test_gcda(:)
         character(len=:), allocatable :: synthesized(:)
         logical :: success
-        
+
         ! Find build directories with coverage data
         call find_coverage_build_directories(build_dirs)
-        
+
         if (.not. allocated(build_dirs) .or. size(build_dirs) == 0) then
             ! Test-friendly path: directly synthesize .gcov from test_build/*.gcda
             test_gcda = find_files('test_build/*.gcda')
@@ -74,7 +74,7 @@ contains
         
         ! Generate gcov files from build directories
         call generate_gcov_from_build_dirs(config, build_dirs, success)
-        
+
         if (success) then
             ! Copy generated .gcov files to project root and collect them
             call collect_generated_gcov_files(build_dirs, all_gcov_files)
@@ -88,10 +88,10 @@ contains
     subroutine find_coverage_build_directories(build_dirs)
         !! Finds build directories containing coverage data files
         character(len=:), allocatable, intent(out) :: build_dirs(:)
-        
+
         character(len=:), allocatable :: gcda_files(:)
         integer :: i
-        
+
         ! Find all .gcda files (indicates executed coverage data)
         ! Use secure recursive discovery to handle various build layouts reliably
         block
@@ -206,9 +206,6 @@ contains
 
         ! Only attempt generation if no .gcov files were discovered
         if (.not. allocated(found_files) .or. size(found_files) == 0) then
-            ! Generate gcov files from .gcda coverage data.
-            ! This handles both explicit --gcov mode (auto_discovery=false)
-            ! and default mode when no .gcov files exist.
             call auto_generate_gcov_files(config, generated_files)
         end if
     end subroutine attempt_gcov_generation

--- a/src/coverage/workflows/coverage_workflows_discovery.f90
+++ b/src/coverage/workflows/coverage_workflows_discovery.f90
@@ -24,10 +24,10 @@ contains
         !! Extracted from original find_coverage_files function
         type(config_t), intent(in) :: config
         character(len=:), allocatable :: files(:)
-        
+
         character(len=:), allocatable :: all_files(:)
         character(len=:), allocatable :: filtered_files(:)
-        
+
         ! Find coverage files based on configuration
         call determine_coverage_files_source(config, all_files)
         
@@ -113,12 +113,10 @@ contains
         !! Determine source of coverage files based on configuration
         type(config_t), intent(in) :: config
         character(len=:), allocatable, intent(out) :: files(:)
-        
+
         if (allocated(config%coverage_files)) then
-            ! Use explicitly specified coverage files
             files = config%coverage_files
         else
-            ! Delegate to gcov processor for discovery (single supported path)
             call discover_gcov_files(config, files)
         end if
     end subroutine determine_coverage_files_source

--- a/src/gcov/gcov_executor.f90
+++ b/src/gcov/gcov_executor.f90
@@ -11,7 +11,7 @@ module gcov_executor
     use file_ops_secure, only: safe_mkdir, safe_move_file
     ! SECURITY FIX Issue #963: safe_execute_gcov removed - shell injection vulnerability
     ! Simplified: avoid security wrapper modules; use minimal local helpers
-    use xml_utils, only: get_base_name
+    use file_utilities, only: basename
     use string_utils, only: int_to_string
     ! Inline security helpers to avoid module-order issues during test builds
     implicit none
@@ -222,7 +222,7 @@ contains
 
         ! Move discovered gcov files to the output directory
         do i = 1, min(size(gcov_files_found), size(temp_files))
-            gcov_basename = get_base_name(gcov_files_found(i))
+            gcov_basename = basename(gcov_files_found(i))
             output_gcov_file = trim(this%gcov_output_dir) // "/" // &
                                trim(gcov_basename)
             call clear_error_context(move_err)


### PR DESCRIPTION
## Summary
- Fixed critical bug preventing `--gcov` mode from generating coverage reports
- Two root causes addressed:
  1. `get_base_name()` stripped `.gcov` extension when moving files to build/gcov/
  2. Empty `coverage_files` array was allocated even with no positional args, skipping auto-discovery

## Test plan
- [x] All existing tests pass (9/9)
- [x] End-to-end workflow verified: `fortcov --gcov` now generates markdown reports
- [x] Verified gcov files are correctly preserved with `.gcov` extension in build/gcov/