### PR TITLE
refactor: extract validate_required_files helper (fixes #1241)

### DIFF
--- a/src/coverage/utils/coverage_validation.f90
+++ b/src/coverage/utils/coverage_validation.f90
@@ -1,6 +1,6 @@
 module coverage_validation
     !! Coverage Analysis Validation Functions
-    !! 
+    !!
     !! Validation functions extracted from coverage_analysis.f90 for maintainability
     !! and adherence to size limits (Issue #333 - Patrick's review feedback).
     use constants_core
@@ -10,60 +10,41 @@ module coverage_validation
     use input_validation_core
     use error_handling_core
     use file_utilities, only: file_exists
-    
+
     implicit none
     private
-    
+
     public :: validate_analysis_configuration
     public :: validate_source_paths
     public :: validate_coverage_files
     public :: validate_exclude_patterns_strict
+    public :: validate_required_files
     public :: display_search_guidance
-    
+
 contains
 
     function validate_analysis_configuration(config) result(is_valid)
         !! Validate configuration settings for analysis
         type(config_t), intent(in) :: config
         logical :: is_valid
-        
-        type(error_context_t) :: error_ctx
-        
+
         is_valid = .true.
-        
-        ! Skip validation for help and version modes
+
+        ! Skip validation for help, version, and config-only modes
         if (config%show_help .or. config%show_version) return
-        
-        ! Skip validation for config-only mode
         if (config%validate_config_only) return
-        
+
         ! Validate source paths if in zero-config mode or if paths are specified
         if (config%zero_configuration_mode .or. &
             (allocated(config%source_paths) .and. size(config%source_paths) > 0)) then
             call validate_source_paths(config, is_valid)
             if (.not. is_valid) return
         end if
-        
-        ! Validate input file exists if specified
-        if (len_trim(config%import_file) > 0) then
-            if (.not. file_exists(config%import_file)) then
-                write(*,'(A)') "Error: Import file does not exist: " // &
-                              trim(config%import_file)
-                is_valid = .false.
-                return
-            end if
-        end if
-        
-        ! Validate diff baseline file exists if diff mode is enabled
-        if (config%enable_diff .and. len_trim(config%diff_baseline_file) > 0) then
-            if (.not. file_exists(config%diff_baseline_file)) then
-                write(*,'(A)') "Error: Diff baseline file does not exist: " // &
-                              trim(config%diff_baseline_file)
-                is_valid = .false.
-                return
-            end if
-        end if
-        
+
+        ! Validate required files (import file, diff baseline)
+        call validate_required_files(config, is_valid)
+        if (.not. is_valid) return
+
         ! Validate exclude patterns in strict mode
         if (config%strict_mode) then
             call validate_exclude_patterns_strict(config, is_valid)
@@ -73,7 +54,6 @@ contains
         ! Validate user-specified coverage files exist
         if (allocated(config%coverage_files) .and. size(config%coverage_files) > 0) then
             call validate_coverage_files(config, is_valid)
-            if (.not. is_valid) return
         end if
 
     end function validate_analysis_configuration
@@ -82,17 +62,17 @@ contains
         !! Validate that source paths exist and are accessible
         type(config_t), intent(in) :: config
         logical, intent(out) :: is_valid
-        
+
         integer :: i
         logical :: path_exists
         character(len=256) :: test_env
         integer :: env_status
-        
+
         is_valid = .true.
-        
+
         ! Check if we're in test mode - allow validation bypass
         call get_environment_variable('FORTCOV_TEST_MODE', test_env, status=env_status)
-        
+
         if (.not. allocated(config%source_paths)) then
             ! In test mode with auto-discovery, allow missing source paths
             if (env_status == 0 .and. config%auto_discovery) then
@@ -103,12 +83,12 @@ contains
             is_valid = .false.
             return
         end if
-        
+
         do i = 1, size(config%source_paths)
-            inquire(file=trim(config%source_paths(i)), exist=path_exists)
+            inquire (file=trim(config%source_paths(i)), exist=path_exists)
             if (.not. path_exists) then
-                write(*,'(A)') "Warning: Source path does not exist: " // &
-                              trim(config%source_paths(i))
+                write (*, '(A)') "Warning: Source path does not exist: "// &
+                    trim(config%source_paths(i))
                 ! Don't fail for missing paths in zero-config mode
                 if (.not. config%zero_configuration_mode) then
                     is_valid = .false.
@@ -116,61 +96,89 @@ contains
                 end if
             end if
         end do
-        
+
         ! Enhanced auto-discovery integration handled elsewhere to avoid circular deps
-        
+
     end subroutine validate_source_paths
+
+    subroutine validate_required_files(config, is_valid)
+        !! Validate that required input files exist (import file, diff baseline)
+        type(config_t), intent(in) :: config
+        logical, intent(inout) :: is_valid
+
+        ! Validate import file exists if specified
+        if (len_trim(config%import_file) > 0) then
+            if (.not. file_exists(config%import_file)) then
+                write (*, '(A)') "Error: Import file does not exist: "// &
+                    trim(config%import_file)
+                is_valid = .false.
+                return
+            end if
+        end if
+
+        ! Validate diff baseline file exists if diff mode is enabled
+        if (config%enable_diff .and. len_trim(config%diff_baseline_file) > 0) then
+            if (.not. file_exists(config%diff_baseline_file)) then
+                write (*, '(A)') "Error: Diff baseline file does not exist: "// &
+                    trim(config%diff_baseline_file)
+                is_valid = .false.
+                return
+            end if
+        end if
+
+    end subroutine validate_required_files
 
     subroutine display_search_guidance(config)
         !! Display guidance for file search when no source paths specified
         type(config_t), intent(in) :: config
-        
-        write(*,'(A)') ""
-        write(*,'(A)') "No source files found for coverage analysis."
-        write(*,'(A)') ""
-        write(*,'(A)') "Try one of the following:"
-        write(*,'(A)') "  1. Specify source directories: fortcov src/"
-        write(*,'(A)') "  2. Use zero-config mode: fortcov --zero-config"
-        write(*,'(A)') "  3. Import existing coverage: fortcov --import coverage.json"
+
+        write (*, '(A)') ""
+        write (*, '(A)') "No source files found for coverage analysis."
+        write (*, '(A)') ""
+        write (*, '(A)') "Try one of the following:"
+        write (*, '(A)') "  1. Specify source directories: fortcov src/"
+        write (*, '(A)') "  2. Use zero-config mode: fortcov --zero-config"
+        write (*, '(A)') "  3. Import existing coverage: fortcov --import coverage.json"
         if (.not. config%auto_discovery) then
-            write(*,'(A)') "  4. Enable auto-discovery: fortcov --auto-discovery"
+            write (*, '(A)') "  4. Enable auto-discovery: fortcov --auto-discovery"
         end if
-        write(*,'(A)') ""
-        
+        write (*, '(A)') ""
+
     end subroutine display_search_guidance
 
     subroutine validate_exclude_patterns_strict(config, is_valid)
         !! Validate exclude patterns in strict mode
         type(config_t), intent(in) :: config
         logical, intent(out) :: is_valid
-        
+
         integer :: i
         character(len=256) :: pattern
-        
+
         is_valid = .true.
-        
+
         if (.not. allocated(config%exclude_patterns)) return
-        
+
         do i = 1, size(config%exclude_patterns)
             pattern = trim(config%exclude_patterns(i))
-            
+
             ! Check for potentially dangerous patterns
             if (len_trim(pattern) == 0) then
-                write(*,'(A)') "Error: Empty exclude pattern not allowed in strict mode"
+                write (*, '(A)') &
+                    "Error: Empty exclude pattern not allowed in strict mode"
                 is_valid = .false.
                 return
             end if
-            
+
             ! Check for overly broad patterns that might exclude everything
             if (pattern == "*" .or. pattern == "**" .or. &
                 pattern == "*.*" .or. pattern == "**/*") then
-                write(*,'(A)') "Error: Overly broad exclude pattern not allowed " // &
-                              "in strict mode: " // trim(pattern)
+                write (*, '(A)') "Error: Overly broad exclude pattern not allowed "// &
+                    "in strict mode: "//trim(pattern)
                 is_valid = .false.
                 return
             end if
         end do
-        
+
     end subroutine validate_exclude_patterns_strict
 
     subroutine validate_coverage_files(config, is_valid)
@@ -191,9 +199,9 @@ contains
             file_path = trim(config%coverage_files(i))
             if (len_trim(file_path) == 0) cycle
 
-            inquire(file=file_path, exist=path_exists)
+            inquire (file=file_path, exist=path_exists)
             if (.not. path_exists) then
-                write(*,'(A)') "Error: File not found: " // file_path
+                write (*, '(A)') "Error: File not found: "//file_path
                 is_valid = .false.
                 return
             end if


### PR DESCRIPTION
## Summary

- Extracts file existence validation (import file and diff baseline) from `validate_analysis_configuration` into a new `validate_required_files` helper subroutine
- Reduces `validate_analysis_configuration` from 55 lines to 34 lines, well under the 50-line soft limit
- Removes unused `error_ctx` variable
- Applies fprettify formatting for consistency

## Verification

```
fpm test 2>&1 | tee /tmp/test.log
```

**Output:**
```
[100%] Project compiled successfully.

Issue #1238: Duplicate File Deduplication Test - 5/5 passed
Issue #1237: Source File Path Handling Test - 5/5 passed  
Issue #1236: Negative fail-under - 3/3 passed
Issue #1123: Logging glitches - 1/1 passed
Issue #364: String concatenation - 4/4 passed
Issue #243: Memory allocation safety - 3/3 passed
Issue #1234: Nonexistent file segfault - 3/3 passed

ALL TESTS PASSED
```

Line count verification:
- `validate_analysis_configuration`: lines 26-59 (34 lines) - under 50-line limit
- `validate_required_files`: lines 104-129 (26 lines) - under 50-line limit